### PR TITLE
Replaced URI fragment `hash (#)` to local path `slash (/)` for build version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 The Human Chromosome Ontology (HCO) provides simple and stable URIs for human reference genome versions to semantically identify human chromosomes.
 
-Basic class `hco:HumanChromosome` is inherited by each chromosome class such as `hco:21` and `hco:GenomeBuild` is inherited by each build version such as `hco:GRCh38`. Then, for example, the human chromosome 21 of the GRCh38 version is represented as `hco:21#GRCh38` (<http://identifiers.org/hco/21#GRCh38>) which is defined as an instance of `hco:21` with build version `hco:GRCh38`. Each instance of a chromosome has links to external resources such as INSDC, RefSeq, UCSC etc. so that users can be navigated to the chromosome sequence and its annotations.
+Basic class `hco:HumanChromosome` is inherited by each chromosome class such as `hco:21` and `hco:GenomeBuild` is inherited by each build version such as `hco:GRCh38`. Then, for example, the human chromosome 21 of the GRCh38 version is represented as `hco:21\/GRCh38` (<http://identifiers.org/hco/21/GRCh38>) which is defined as an instance of `hco:21` with build version `hco:GRCh38`. Each instance of a chromosome has links to external resources such as INSDC, RefSeq, UCSC etc. so that users can be navigated to the chromosome sequence and its annotations.
 
 ```
 hco:21
         rdfs:label      "Human chromosome 21" ;
         rdfs:subClassOf hco:HumanChromosome .
 
-hco:21#GRCh38
+hco:21\/GRCh38
         rdf:type        hco:21 ;
         hco:build       hco:GRCh38 ;
         hco:length      46709983 ;
@@ -28,7 +28,7 @@ hco:21q11.2
         rdfs:label      "21q11.2" ;
         rdfs:subClassOf hco:Cytoband .
 
-hco:21q11.2#GRCh38
+hco:21q11.2\/GRCh38
         rdf:type        hco:21q11.2 ;
         hco:build       hco:GRCh38 ;
         hco:bandtype    hco:Gneg ;
@@ -37,12 +37,12 @@ hco:21q11.2#GRCh38
                 faldo:begin      [
                         rdf:type         faldo:BothStrandsPosition ;
                         faldo:position   13000000 ;
-                        faldo:reference  hco:21#GRCh38
+                        faldo:reference  hco:21\/GRCh38
                 ] ;
                 faldo:end        [
                         rdf:type         faldo:BothStrandsPosition ;
                         faldo:position   15000000 ;
-                        faldo:reference  hco:21#GRCh38
+                        faldo:reference  hco:21\/GRCh38
                 ]
         ] .
 ```
@@ -50,5 +50,5 @@ hco:21q11.2#GRCh38
 ### Contributors
 
 * Toshiaki Katayama (Database Center for Life Science)
-* The MED2RDF project <http://med2rdf.org/>
+* The Med2RDF project <http://med2rdf.org/>
 * The 3rd RDF summit <https://github.com/dbcls/rdfsummit3>

--- a/cytoBand2ttl.rb
+++ b/cytoBand2ttl.rb
@@ -3,6 +3,7 @@
 # $ curl http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz | gzip -dc - > cytoBand-GRCh37.txt
 # $ curl http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz | gzip -dc - > cytoBand-GRCh38.txt
 # $ ruby cytoBand2ttl.rb > cytoBand.ttl
+# $ cat hco_head.owl cytoBand.ttl > hco.owl
 #
 
 hash = {}
@@ -33,20 +34,12 @@ versions.each do |ver|
           :to   => to.to_i,
           :cyto => cyto,
           :col  => col,
-          :ref  => "hco:#{num}##{ver}"
+          :ref  => "hco:#{num}\\/#{ver}"
         }
       end
     end
   end
 end
-
-puts "
-@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix faldo: <http://biohackathon.org/resource/faldo#> .
-@prefix hco:   <http://identifiers.org/hco/> .
-
-"
 
 hash.each do |cyto, data|
   puts "hco:#{cyto}"
@@ -55,7 +48,7 @@ hash.each do |cyto, data|
   puts
   versions.each do |ver|
     h = data[ver]
-    puts "hco:#{cyto}##{ver}"
+    puts "hco:#{cyto}\\/#{ver}"
     puts "\trdf:type\thco:#{cyto} ;"
     puts "\thco:build\thco:#{ver} ;"
     puts "\thco:bandtype\t#{cytoband_type[h[:col]]} ;"

--- a/hco.owl
+++ b/hco.owl
@@ -88,7 +88,7 @@ hco:1
 	rdfs:label	"Human chromosome 1" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:1#GRCh37
+hco:1\/GRCh37
 	rdf:type	hco:1 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	249250621 ;
@@ -99,7 +99,7 @@ hco:1#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/1> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=1> .
 
-hco:1#GRCh38
+hco:1\/GRCh38
 	rdf:type	hco:1 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	248956422 ;
@@ -114,7 +114,7 @@ hco:2
 	rdfs:label	"Human chromosome 2" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:2#GRCh37
+hco:2\/GRCh37
 	rdf:type	hco:2 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	243199373 ;
@@ -125,7 +125,7 @@ hco:2#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/2> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=2> .
 
-hco:2#GRCh38
+hco:2\/GRCh38
 	rdf:type	hco:2 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	242193529 ;
@@ -140,7 +140,7 @@ hco:3
 	rdfs:label	"Human chromosome 3" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:3#GRCh37
+hco:3\/GRCh37
 	rdf:type	hco:3 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	198022430 ;
@@ -151,7 +151,7 @@ hco:3#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/3> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=3> .
 
-hco:3#GRCh38
+hco:3\/GRCh38
 	rdf:type	hco:3 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	198295559 ;
@@ -166,7 +166,7 @@ hco:4
 	rdfs:label	"Human chromosome 4" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:4#GRCh37
+hco:4\/GRCh37
 	rdf:type	hco:4 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	191154276 ;
@@ -177,7 +177,7 @@ hco:4#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/4> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=4> .
 
-hco:4#GRCh38
+hco:4\/GRCh38
 	rdf:type	hco:4 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	190214555 ;
@@ -192,7 +192,7 @@ hco:5
 	rdfs:label	"Human chromosome 5" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:5#GRCh37
+hco:5\/GRCh37
 	rdf:type	hco:5 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	180915260 ;
@@ -203,7 +203,7 @@ hco:5#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/5> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=5> .
 
-hco:5#GRCh38
+hco:5\/GRCh38
 	rdf:type	hco:5 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	181538259 ;
@@ -218,7 +218,7 @@ hco:6
 	rdfs:label	"Human chromosome 6" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:6#GRCh37
+hco:6\/GRCh37
 	rdf:type	hco:6 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	171115067 ;
@@ -229,7 +229,7 @@ hco:6#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/6> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=6> .
 
-hco:6#GRCh38
+hco:6\/GRCh38
 	rdf:type	hco:6 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	170805979 ;
@@ -244,7 +244,7 @@ hco:7
 	rdfs:label	"Human chromosome 7" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:7#GRCh37
+hco:7\/GRCh37
 	rdf:type	hco:7 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	159138663 ;
@@ -255,7 +255,7 @@ hco:7#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/7> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=7> .
 
-hco:7#GRCh38
+hco:7\/GRCh38
 	rdf:type	hco:7 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	159345973 ;
@@ -270,7 +270,7 @@ hco:8
 	rdfs:label	"Human chromosome 8" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:8#GRCh37
+hco:8\/GRCh37
 	rdf:type	hco:8 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	146364022 ;
@@ -281,7 +281,7 @@ hco:8#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/8> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=8> .
 
-hco:8#GRCh38
+hco:8\/GRCh38
 	rdf:type	hco:8 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	145138636 ;
@@ -296,7 +296,7 @@ hco:9
 	rdfs:label	"Human chromosome 9" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:9#GRCh37
+hco:9\/GRCh37
 	rdf:type	hco:9 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	141213431 ;
@@ -307,7 +307,7 @@ hco:9#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/9> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=9> .
 
-hco:9#GRCh38
+hco:9\/GRCh38
 	rdf:type	hco:9 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	138394717 ;
@@ -322,7 +322,7 @@ hco:10
 	rdfs:label	"Human chromosome 10" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:10#GRCh37
+hco:10\/GRCh37
 	rdf:type	hco:10 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	135534747 ;
@@ -333,7 +333,7 @@ hco:10#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/10> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=10> .
 
-hco:10#GRCh38
+hco:10\/GRCh38
 	rdf:type	hco:1 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	133797422 ;
@@ -348,7 +348,7 @@ hco:11
 	rdfs:label	"Human chromosome 11" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:11#GRCh37
+hco:11\/GRCh37
 	rdf:type	hco:11 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	135006516 ;
@@ -359,7 +359,7 @@ hco:11#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/11> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=11> .
 
-hco:11#GRCh38
+hco:11\/GRCh38
 	rdf:type	hco:11 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	135086622 ;
@@ -374,7 +374,7 @@ hco:12
 	rdfs:label	"Human chromosome 12" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:12#GRCh37
+hco:12\/GRCh37
 	rdf:type	hco:12 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	133851895 ;
@@ -385,7 +385,7 @@ hco:12#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/12> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=12> .
 
-hco:12#GRCh38
+hco:12\/GRCh38
 	rdf:type	hco:12 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	133275309 ;
@@ -400,7 +400,7 @@ hco:13
 	rdfs:label	"Human chromosome 13" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:13#GRCh37
+hco:13\/GRCh37
 	rdf:type	hco:13 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	115169878 ;
@@ -411,7 +411,7 @@ hco:13#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/13> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=13> .
 
-hco:13#GRCh38
+hco:13\/GRCh38
 	rdf:type	hco:13 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	114364328 ;
@@ -426,7 +426,7 @@ hco:14
 	rdfs:label	"Human chromosome 14" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:14#GRCh37
+hco:14\/GRCh37
 	rdf:type	hco:14 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	107349540 ;
@@ -437,7 +437,7 @@ hco:14#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/14> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=14> .
 
-hco:14#GRCh38
+hco:14\/GRCh38
 	rdf:type	hco:14 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	107043718 ;
@@ -452,7 +452,7 @@ hco:15
 	rdfs:label	"Human chromosome 15" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:15#GRCh37
+hco:15\/GRCh37
 	rdf:type	hco:15 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	102531392 ;
@@ -463,7 +463,7 @@ hco:15#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/15> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=15> .
 
-hco:15#GRCh38
+hco:15\/GRCh38
 	rdf:type	hco:15 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	101991189 ;
@@ -478,7 +478,7 @@ hco:16
 	rdfs:label	"Human chromosome 16" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:16#GRCh37
+hco:16\/GRCh37
 	rdf:type	hco:16 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	90354753 ;
@@ -489,7 +489,7 @@ hco:16#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/16> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=16> .
 
-hco:16#GRCh38
+hco:16\/GRCh38
 	rdf:type	hco:16 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	90338345 ;
@@ -504,7 +504,7 @@ hco:17
 	rdfs:label	"Human chromosome 17" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:17#GRCh37
+hco:17\/GRCh37
 	rdf:type	hco:17 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	81195210 ;
@@ -515,7 +515,7 @@ hco:17#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/17> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=17> .
 
-hco:17#GRCh38
+hco:17\/GRCh38
 	rdf:type	hco:17 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	83257441 ;
@@ -530,7 +530,7 @@ hco:18
 	rdfs:label	"Human chromosome 18" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:18#GRCh37
+hco:18\/GRCh37
 	rdf:type	hco:18 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	78077248 ;
@@ -541,7 +541,7 @@ hco:18#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/18> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=18> .
 
-hco:18#GRCh38
+hco:18\/GRCh38
 	rdf:type	hco:18 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	80373285 ;
@@ -556,7 +556,7 @@ hco:19
 	rdfs:label	"Human chromosome 19" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:19#GRCh37
+hco:19\/GRCh37
 	rdf:type	hco:19 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	59128983 ;
@@ -567,7 +567,7 @@ hco:19#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/19> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=19> .
 
-hco:19#GRCh38
+hco:19\/GRCh38
 	rdf:type	hco:19 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	58617616 ;
@@ -582,7 +582,7 @@ hco:20
 	rdfs:label	"Human chromosome 20" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:20#GRCh37
+hco:20\/GRCh37
 	rdf:type	hco:20 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	63025520 ;
@@ -593,7 +593,7 @@ hco:20#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/20> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=20> .
 
-hco:20#GRCh38
+hco:20\/GRCh38
 	rdf:type	hco:20 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	64444167 ;
@@ -608,7 +608,7 @@ hco:21
 	rdfs:label	"Human chromosome 21" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:21#GRCh37
+hco:21\/GRCh37
 	rdf:type	hco:21 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	48129895 ;
@@ -619,7 +619,7 @@ hco:21#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/21> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=21> .
 
-hco:21#GRCh38
+hco:21\/GRCh38
 	rdf:type	hco:21 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	46709983 ;
@@ -634,7 +634,7 @@ hco:22
 	rdfs:label	"Human chromosome 22" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:22#GRCh37
+hco:22\/GRCh37
 	rdf:type	hco:22 ;
 	hco:build	hco:GRCh37 ;
 	hco:length	51304566 ;
@@ -645,7 +645,7 @@ hco:22#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/22> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=22> .
 
-hco:22#GRCh38
+hco:22\/GRCh38
 	rdf:type	hco:22 ;
 	hco:build	hco:GRCh38 ;
 	hco:length	50818468 ;
@@ -660,7 +660,7 @@ hco:X
 	rdfs:label	"Human chromosome X" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:X#GRCh37
+hco:X\/GRCh37
 	rdf:type	hco:X ;
 	hco:build	hco:GRCh37 ;
 	hco:length	155270560 ;
@@ -671,7 +671,7 @@ hco:X#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/X> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=X> .
 
-hco:X#GRCh38
+hco:X\/GRCh38
 	rdf:type	hco:X ;
 	hco:build	hco:GRCh38 ;
 	hco:length	156040895 ;
@@ -686,7 +686,7 @@ hco:Y
 	rdfs:label	"Human chromosome Y" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:Y#GRCh37
+hco:Y\/GRCh37
 	rdf:type	hco:Y ;
 	hco:build	hco:GRCh37 ;
 	hco:length	59373566 ;
@@ -697,7 +697,7 @@ hco:Y#GRCh37
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/Y> ,
 			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=Y> .
 
-hco:Y#GRCh38
+hco:Y\/GRCh38
 	rdf:type	hco:Y ;
 	hco:build	hco:GRCh38 ;
 	hco:length	57227415 ;
@@ -712,7 +712,7 @@ hco:MT
 	rdfs:label	"Human mitochondrion genome" ;
 	rdfs:subClassOf	hco:HumanChromosome .
 
-hco:MT#GRCh37
+hco:MT\/GRCh37
 	rdf:type	hco:MT ;
 	hco:length	16569 ;
 	skos:altLabel	"AC_000021" ;
@@ -720,7 +720,7 @@ hco:MT#GRCh37
 	hco:refseq	<http://identifiers.org/refseq/NC_012920.1> ;
 	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/MT> .
 
-hco:MT#GRCh38
+hco:MT\/GRCh38
 	rdf:type	hco:MT ;
 	hco:length	16569 ;
 	skos:altLabel	"AC_000021" ;
@@ -846,7 +846,7 @@ hco:1p36.33
 	rdfs:label	"1p36.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.33#GRCh37
+hco:1p36.33\/GRCh37
 	rdf:type	hco:1p36.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -855,16 +855,16 @@ hco:1p36.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.33#GRCh38
+hco:1p36.33\/GRCh38
 	rdf:type	hco:1p36.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -873,12 +873,12 @@ hco:1p36.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -886,7 +886,7 @@ hco:1p36.32
 	rdfs:label	"1p36.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.32#GRCh37
+hco:1p36.32\/GRCh37
 	rdf:type	hco:1p36.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -895,16 +895,16 @@ hco:1p36.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.32#GRCh38
+hco:1p36.32\/GRCh38
 	rdf:type	hco:1p36.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -913,12 +913,12 @@ hco:1p36.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -926,7 +926,7 @@ hco:1p36.31
 	rdfs:label	"1p36.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.31#GRCh37
+hco:1p36.31\/GRCh37
 	rdf:type	hco:1p36.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -935,16 +935,16 @@ hco:1p36.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.31#GRCh38
+hco:1p36.31\/GRCh38
 	rdf:type	hco:1p36.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -953,12 +953,12 @@ hco:1p36.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -966,7 +966,7 @@ hco:1p36.23
 	rdfs:label	"1p36.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.23#GRCh37
+hco:1p36.23\/GRCh37
 	rdf:type	hco:1p36.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -975,16 +975,16 @@ hco:1p36.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.23#GRCh38
+hco:1p36.23\/GRCh38
 	rdf:type	hco:1p36.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -993,12 +993,12 @@ hco:1p36.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1006,7 +1006,7 @@ hco:1p36.22
 	rdfs:label	"1p36.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.22#GRCh37
+hco:1p36.22\/GRCh37
 	rdf:type	hco:1p36.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1015,16 +1015,16 @@ hco:1p36.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.22#GRCh38
+hco:1p36.22\/GRCh38
 	rdf:type	hco:1p36.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1033,12 +1033,12 @@ hco:1p36.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1046,7 +1046,7 @@ hco:1p36.21
 	rdfs:label	"1p36.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.21#GRCh37
+hco:1p36.21\/GRCh37
 	rdf:type	hco:1p36.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1055,16 +1055,16 @@ hco:1p36.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.21#GRCh38
+hco:1p36.21\/GRCh38
 	rdf:type	hco:1p36.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1073,12 +1073,12 @@ hco:1p36.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1086,7 +1086,7 @@ hco:1p36.13
 	rdfs:label	"1p36.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.13#GRCh37
+hco:1p36.13\/GRCh37
 	rdf:type	hco:1p36.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1095,16 +1095,16 @@ hco:1p36.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.13#GRCh38
+hco:1p36.13\/GRCh38
 	rdf:type	hco:1p36.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1113,12 +1113,12 @@ hco:1p36.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1126,7 +1126,7 @@ hco:1p36.12
 	rdfs:label	"1p36.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.12#GRCh37
+hco:1p36.12\/GRCh37
 	rdf:type	hco:1p36.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1135,16 +1135,16 @@ hco:1p36.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.12#GRCh38
+hco:1p36.12\/GRCh38
 	rdf:type	hco:1p36.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1153,12 +1153,12 @@ hco:1p36.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1166,7 +1166,7 @@ hco:1p36.11
 	rdfs:label	"1p36.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p36.11#GRCh37
+hco:1p36.11\/GRCh37
 	rdf:type	hco:1p36.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1175,16 +1175,16 @@ hco:1p36.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p36.11#GRCh38
+hco:1p36.11\/GRCh38
 	rdf:type	hco:1p36.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1193,12 +1193,12 @@ hco:1p36.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1206,7 +1206,7 @@ hco:1p35.3
 	rdfs:label	"1p35.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p35.3#GRCh37
+hco:1p35.3\/GRCh37
 	rdf:type	hco:1p35.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1215,16 +1215,16 @@ hco:1p35.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p35.3#GRCh38
+hco:1p35.3\/GRCh38
 	rdf:type	hco:1p35.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1233,12 +1233,12 @@ hco:1p35.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1246,7 +1246,7 @@ hco:1p35.2
 	rdfs:label	"1p35.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p35.2#GRCh37
+hco:1p35.2\/GRCh37
 	rdf:type	hco:1p35.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1255,16 +1255,16 @@ hco:1p35.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p35.2#GRCh38
+hco:1p35.2\/GRCh38
 	rdf:type	hco:1p35.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1273,12 +1273,12 @@ hco:1p35.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1286,7 +1286,7 @@ hco:1p35.1
 	rdfs:label	"1p35.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p35.1#GRCh37
+hco:1p35.1\/GRCh37
 	rdf:type	hco:1p35.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1295,16 +1295,16 @@ hco:1p35.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p35.1#GRCh38
+hco:1p35.1\/GRCh38
 	rdf:type	hco:1p35.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1313,12 +1313,12 @@ hco:1p35.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1326,7 +1326,7 @@ hco:1p34.3
 	rdfs:label	"1p34.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p34.3#GRCh37
+hco:1p34.3\/GRCh37
 	rdf:type	hco:1p34.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1335,16 +1335,16 @@ hco:1p34.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p34.3#GRCh38
+hco:1p34.3\/GRCh38
 	rdf:type	hco:1p34.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1353,12 +1353,12 @@ hco:1p34.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1366,7 +1366,7 @@ hco:1p34.2
 	rdfs:label	"1p34.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p34.2#GRCh37
+hco:1p34.2\/GRCh37
 	rdf:type	hco:1p34.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1375,16 +1375,16 @@ hco:1p34.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p34.2#GRCh38
+hco:1p34.2\/GRCh38
 	rdf:type	hco:1p34.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -1393,12 +1393,12 @@ hco:1p34.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1406,7 +1406,7 @@ hco:1p34.1
 	rdfs:label	"1p34.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p34.1#GRCh37
+hco:1p34.1\/GRCh37
 	rdf:type	hco:1p34.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1415,16 +1415,16 @@ hco:1p34.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p34.1#GRCh38
+hco:1p34.1\/GRCh38
 	rdf:type	hco:1p34.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1433,12 +1433,12 @@ hco:1p34.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1446,7 +1446,7 @@ hco:1p33
 	rdfs:label	"1p33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p33#GRCh37
+hco:1p33\/GRCh37
 	rdf:type	hco:1p33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1455,16 +1455,16 @@ hco:1p33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p33#GRCh38
+hco:1p33\/GRCh38
 	rdf:type	hco:1p33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1473,12 +1473,12 @@ hco:1p33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1486,7 +1486,7 @@ hco:1p32.3
 	rdfs:label	"1p32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p32.3#GRCh37
+hco:1p32.3\/GRCh37
 	rdf:type	hco:1p32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1495,16 +1495,16 @@ hco:1p32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p32.3#GRCh38
+hco:1p32.3\/GRCh38
 	rdf:type	hco:1p32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1513,12 +1513,12 @@ hco:1p32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1526,7 +1526,7 @@ hco:1p32.2
 	rdfs:label	"1p32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p32.2#GRCh37
+hco:1p32.2\/GRCh37
 	rdf:type	hco:1p32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1535,16 +1535,16 @@ hco:1p32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p32.2#GRCh38
+hco:1p32.2\/GRCh38
 	rdf:type	hco:1p32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1553,12 +1553,12 @@ hco:1p32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1566,7 +1566,7 @@ hco:1p32.1
 	rdfs:label	"1p32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p32.1#GRCh37
+hco:1p32.1\/GRCh37
 	rdf:type	hco:1p32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1575,16 +1575,16 @@ hco:1p32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p32.1#GRCh38
+hco:1p32.1\/GRCh38
 	rdf:type	hco:1p32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1593,12 +1593,12 @@ hco:1p32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1606,7 +1606,7 @@ hco:1p31.3
 	rdfs:label	"1p31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p31.3#GRCh37
+hco:1p31.3\/GRCh37
 	rdf:type	hco:1p31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1615,16 +1615,16 @@ hco:1p31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p31.3#GRCh38
+hco:1p31.3\/GRCh38
 	rdf:type	hco:1p31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -1633,12 +1633,12 @@ hco:1p31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1646,7 +1646,7 @@ hco:1p31.2
 	rdfs:label	"1p31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p31.2#GRCh37
+hco:1p31.2\/GRCh37
 	rdf:type	hco:1p31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1655,16 +1655,16 @@ hco:1p31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p31.2#GRCh38
+hco:1p31.2\/GRCh38
 	rdf:type	hco:1p31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1673,12 +1673,12 @@ hco:1p31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1686,7 +1686,7 @@ hco:1p31.1
 	rdfs:label	"1p31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p31.1#GRCh37
+hco:1p31.1\/GRCh37
 	rdf:type	hco:1p31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -1695,16 +1695,16 @@ hco:1p31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p31.1#GRCh38
+hco:1p31.1\/GRCh38
 	rdf:type	hco:1p31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -1713,12 +1713,12 @@ hco:1p31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1726,7 +1726,7 @@ hco:1p22.3
 	rdfs:label	"1p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p22.3#GRCh37
+hco:1p22.3\/GRCh37
 	rdf:type	hco:1p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1735,16 +1735,16 @@ hco:1p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p22.3#GRCh38
+hco:1p22.3\/GRCh38
 	rdf:type	hco:1p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1753,12 +1753,12 @@ hco:1p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1766,7 +1766,7 @@ hco:1p22.2
 	rdfs:label	"1p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p22.2#GRCh37
+hco:1p22.2\/GRCh37
 	rdf:type	hco:1p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1775,16 +1775,16 @@ hco:1p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88400000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p22.2#GRCh38
+hco:1p22.2\/GRCh38
 	rdf:type	hco:1p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1793,12 +1793,12 @@ hco:1p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1806,7 +1806,7 @@ hco:1p22.1
 	rdfs:label	"1p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p22.1#GRCh37
+hco:1p22.1\/GRCh37
 	rdf:type	hco:1p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1815,16 +1815,16 @@ hco:1p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p22.1#GRCh38
+hco:1p22.1\/GRCh38
 	rdf:type	hco:1p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1833,12 +1833,12 @@ hco:1p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1846,7 +1846,7 @@ hco:1p21.3
 	rdfs:label	"1p21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p21.3#GRCh37
+hco:1p21.3\/GRCh37
 	rdf:type	hco:1p21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1855,16 +1855,16 @@ hco:1p21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p21.3#GRCh38
+hco:1p21.3\/GRCh38
 	rdf:type	hco:1p21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -1873,12 +1873,12 @@ hco:1p21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1886,7 +1886,7 @@ hco:1p21.2
 	rdfs:label	"1p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p21.2#GRCh37
+hco:1p21.2\/GRCh37
 	rdf:type	hco:1p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1895,16 +1895,16 @@ hco:1p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p21.2#GRCh38
+hco:1p21.2\/GRCh38
 	rdf:type	hco:1p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1913,12 +1913,12 @@ hco:1p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1926,7 +1926,7 @@ hco:1p21.1
 	rdfs:label	"1p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p21.1#GRCh37
+hco:1p21.1\/GRCh37
 	rdf:type	hco:1p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -1935,16 +1935,16 @@ hco:1p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p21.1#GRCh38
+hco:1p21.1\/GRCh38
 	rdf:type	hco:1p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -1953,12 +1953,12 @@ hco:1p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -1966,7 +1966,7 @@ hco:1p13.3
 	rdfs:label	"1p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p13.3#GRCh37
+hco:1p13.3\/GRCh37
 	rdf:type	hco:1p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -1975,16 +1975,16 @@ hco:1p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p13.3#GRCh38
+hco:1p13.3\/GRCh38
 	rdf:type	hco:1p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -1993,12 +1993,12 @@ hco:1p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2006,7 +2006,7 @@ hco:1p13.2
 	rdfs:label	"1p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p13.2#GRCh37
+hco:1p13.2\/GRCh37
 	rdf:type	hco:1p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2015,16 +2015,16 @@ hco:1p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p13.2#GRCh38
+hco:1p13.2\/GRCh38
 	rdf:type	hco:1p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2033,12 +2033,12 @@ hco:1p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2046,7 +2046,7 @@ hco:1p13.1
 	rdfs:label	"1p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p13.1#GRCh37
+hco:1p13.1\/GRCh37
 	rdf:type	hco:1p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2055,16 +2055,16 @@ hco:1p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p13.1#GRCh38
+hco:1p13.1\/GRCh38
 	rdf:type	hco:1p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2073,12 +2073,12 @@ hco:1p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2086,7 +2086,7 @@ hco:1p12
 	rdfs:label	"1p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p12#GRCh37
+hco:1p12\/GRCh37
 	rdf:type	hco:1p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2095,16 +2095,16 @@ hco:1p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p12#GRCh38
+hco:1p12\/GRCh38
 	rdf:type	hco:1p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2113,12 +2113,12 @@ hco:1p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2126,7 +2126,7 @@ hco:1p11.2
 	rdfs:label	"1p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p11.2#GRCh37
+hco:1p11.2\/GRCh37
 	rdf:type	hco:1p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2135,16 +2135,16 @@ hco:1p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p11.2#GRCh38
+hco:1p11.2\/GRCh38
 	rdf:type	hco:1p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2153,12 +2153,12 @@ hco:1p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2166,7 +2166,7 @@ hco:1p11.1
 	rdfs:label	"1p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1p11.1#GRCh37
+hco:1p11.1\/GRCh37
 	rdf:type	hco:1p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -2175,16 +2175,16 @@ hco:1p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1p11.1#GRCh38
+hco:1p11.1\/GRCh38
 	rdf:type	hco:1p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -2193,12 +2193,12 @@ hco:1p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2206,7 +2206,7 @@ hco:1q11
 	rdfs:label	"1q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q11#GRCh37
+hco:1q11\/GRCh37
 	rdf:type	hco:1q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -2215,16 +2215,16 @@ hco:1q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q11#GRCh38
+hco:1q11\/GRCh38
 	rdf:type	hco:1q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -2233,12 +2233,12 @@ hco:1q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2246,7 +2246,7 @@ hco:1q12
 	rdfs:label	"1q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q12#GRCh37
+hco:1q12\/GRCh37
 	rdf:type	hco:1q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -2255,16 +2255,16 @@ hco:1q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q12#GRCh38
+hco:1q12\/GRCh38
 	rdf:type	hco:1q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -2273,12 +2273,12 @@ hco:1q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2286,7 +2286,7 @@ hco:1q21.1
 	rdfs:label	"1q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q21.1#GRCh37
+hco:1q21.1\/GRCh37
 	rdf:type	hco:1q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2295,16 +2295,16 @@ hco:1q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q21.1#GRCh38
+hco:1q21.1\/GRCh38
 	rdf:type	hco:1q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2313,12 +2313,12 @@ hco:1q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2326,7 +2326,7 @@ hco:1q21.2
 	rdfs:label	"1q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q21.2#GRCh37
+hco:1q21.2\/GRCh37
 	rdf:type	hco:1q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2335,16 +2335,16 @@ hco:1q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q21.2#GRCh38
+hco:1q21.2\/GRCh38
 	rdf:type	hco:1q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2353,12 +2353,12 @@ hco:1q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2366,7 +2366,7 @@ hco:1q21.3
 	rdfs:label	"1q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q21.3#GRCh37
+hco:1q21.3\/GRCh37
 	rdf:type	hco:1q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2375,16 +2375,16 @@ hco:1q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q21.3#GRCh38
+hco:1q21.3\/GRCh38
 	rdf:type	hco:1q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2393,12 +2393,12 @@ hco:1q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2406,7 +2406,7 @@ hco:1q22
 	rdfs:label	"1q22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q22#GRCh37
+hco:1q22\/GRCh37
 	rdf:type	hco:1q22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2415,16 +2415,16 @@ hco:1q22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q22#GRCh38
+hco:1q22\/GRCh38
 	rdf:type	hco:1q22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2433,12 +2433,12 @@ hco:1q22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2446,7 +2446,7 @@ hco:1q23.1
 	rdfs:label	"1q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q23.1#GRCh37
+hco:1q23.1\/GRCh37
 	rdf:type	hco:1q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2455,16 +2455,16 @@ hco:1q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q23.1#GRCh38
+hco:1q23.1\/GRCh38
 	rdf:type	hco:1q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2473,12 +2473,12 @@ hco:1q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2486,7 +2486,7 @@ hco:1q23.2
 	rdfs:label	"1q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q23.2#GRCh37
+hco:1q23.2\/GRCh37
 	rdf:type	hco:1q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2495,16 +2495,16 @@ hco:1q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q23.2#GRCh38
+hco:1q23.2\/GRCh38
 	rdf:type	hco:1q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2513,12 +2513,12 @@ hco:1q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2526,7 +2526,7 @@ hco:1q23.3
 	rdfs:label	"1q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q23.3#GRCh37
+hco:1q23.3\/GRCh37
 	rdf:type	hco:1q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2535,16 +2535,16 @@ hco:1q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	165500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q23.3#GRCh38
+hco:1q23.3\/GRCh38
 	rdf:type	hco:1q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2553,12 +2553,12 @@ hco:1q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	165500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2566,7 +2566,7 @@ hco:1q24.1
 	rdfs:label	"1q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q24.1#GRCh37
+hco:1q24.1\/GRCh37
 	rdf:type	hco:1q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2575,16 +2575,16 @@ hco:1q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	165500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q24.1#GRCh38
+hco:1q24.1\/GRCh38
 	rdf:type	hco:1q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2593,12 +2593,12 @@ hco:1q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	165500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2606,7 +2606,7 @@ hco:1q24.2
 	rdfs:label	"1q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q24.2#GRCh37
+hco:1q24.2\/GRCh37
 	rdf:type	hco:1q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2615,16 +2615,16 @@ hco:1q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q24.2#GRCh38
+hco:1q24.2\/GRCh38
 	rdf:type	hco:1q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2633,12 +2633,12 @@ hco:1q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167200000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2646,7 +2646,7 @@ hco:1q24.3
 	rdfs:label	"1q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q24.3#GRCh37
+hco:1q24.3\/GRCh37
 	rdf:type	hco:1q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -2655,16 +2655,16 @@ hco:1q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	172900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q24.3#GRCh38
+hco:1q24.3\/GRCh38
 	rdf:type	hco:1q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -2673,12 +2673,12 @@ hco:1q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	173000000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2686,7 +2686,7 @@ hco:1q25.1
 	rdfs:label	"1q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q25.1#GRCh37
+hco:1q25.1\/GRCh37
 	rdf:type	hco:1q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2695,16 +2695,16 @@ hco:1q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	172900000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q25.1#GRCh38
+hco:1q25.1\/GRCh38
 	rdf:type	hco:1q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2713,12 +2713,12 @@ hco:1q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	173000000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2726,7 +2726,7 @@ hco:1q25.2
 	rdfs:label	"1q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q25.2#GRCh37
+hco:1q25.2\/GRCh37
 	rdf:type	hco:1q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2735,16 +2735,16 @@ hco:1q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q25.2#GRCh38
+hco:1q25.2\/GRCh38
 	rdf:type	hco:1q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -2753,12 +2753,12 @@ hco:1q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2766,7 +2766,7 @@ hco:1q25.3
 	rdfs:label	"1q25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q25.3#GRCh37
+hco:1q25.3\/GRCh37
 	rdf:type	hco:1q25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2775,16 +2775,16 @@ hco:1q25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180300000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	185800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q25.3#GRCh38
+hco:1q25.3\/GRCh38
 	rdf:type	hco:1q25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2793,12 +2793,12 @@ hco:1q25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	185800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2806,7 +2806,7 @@ hco:1q31.1
 	rdfs:label	"1q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q31.1#GRCh37
+hco:1q31.1\/GRCh37
 	rdf:type	hco:1q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -2815,16 +2815,16 @@ hco:1q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	185800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	190800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q31.1#GRCh38
+hco:1q31.1\/GRCh38
 	rdf:type	hco:1q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -2833,12 +2833,12 @@ hco:1q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	185800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	190800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2846,7 +2846,7 @@ hco:1q31.2
 	rdfs:label	"1q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q31.2#GRCh37
+hco:1q31.2\/GRCh37
 	rdf:type	hco:1q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2855,16 +2855,16 @@ hco:1q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	190800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	193800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q31.2#GRCh38
+hco:1q31.2\/GRCh38
 	rdf:type	hco:1q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2873,12 +2873,12 @@ hco:1q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	190800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	193800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2886,7 +2886,7 @@ hco:1q31.3
 	rdfs:label	"1q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q31.3#GRCh37
+hco:1q31.3\/GRCh37
 	rdf:type	hco:1q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -2895,16 +2895,16 @@ hco:1q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	193800000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q31.3#GRCh38
+hco:1q31.3\/GRCh38
 	rdf:type	hco:1q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -2913,12 +2913,12 @@ hco:1q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	193800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2926,7 +2926,7 @@ hco:1q32.1
 	rdfs:label	"1q32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q32.1#GRCh37
+hco:1q32.1\/GRCh37
 	rdf:type	hco:1q32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -2935,16 +2935,16 @@ hco:1q32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	207200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q32.1#GRCh38
+hco:1q32.1\/GRCh38
 	rdf:type	hco:1q32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -2953,12 +2953,12 @@ hco:1q32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198700000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	207100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -2966,7 +2966,7 @@ hco:1q32.2
 	rdfs:label	"1q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q32.2#GRCh37
+hco:1q32.2\/GRCh37
 	rdf:type	hco:1q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -2975,16 +2975,16 @@ hco:1q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	207200000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	211500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q32.2#GRCh38
+hco:1q32.2\/GRCh38
 	rdf:type	hco:1q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -2993,12 +2993,12 @@ hco:1q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	207100000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	211300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3006,7 +3006,7 @@ hco:1q32.3
 	rdfs:label	"1q32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q32.3#GRCh37
+hco:1q32.3\/GRCh37
 	rdf:type	hco:1q32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3015,16 +3015,16 @@ hco:1q32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	211500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q32.3#GRCh38
+hco:1q32.3\/GRCh38
 	rdf:type	hco:1q32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3033,12 +3033,12 @@ hco:1q32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	211300000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3046,7 +3046,7 @@ hco:1q41
 	rdfs:label	"1q41" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q41#GRCh37
+hco:1q41\/GRCh37
 	rdf:type	hco:1q41 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -3055,16 +3055,16 @@ hco:1q41#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214500000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q41#GRCh38
+hco:1q41\/GRCh38
 	rdf:type	hco:1q41 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -3073,12 +3073,12 @@ hco:1q41#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	223900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3086,7 +3086,7 @@ hco:1q42.11
 	rdfs:label	"1q42.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q42.11#GRCh37
+hco:1q42.11\/GRCh37
 	rdf:type	hco:1q42.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3095,16 +3095,16 @@ hco:1q42.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224100000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q42.11#GRCh38
+hco:1q42.11\/GRCh38
 	rdf:type	hco:1q42.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3113,12 +3113,12 @@ hco:1q42.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	223900000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3126,7 +3126,7 @@ hco:1q42.12
 	rdfs:label	"1q42.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q42.12#GRCh37
+hco:1q42.12\/GRCh37
 	rdf:type	hco:1q42.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3135,16 +3135,16 @@ hco:1q42.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	227000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q42.12#GRCh38
+hco:1q42.12\/GRCh38
 	rdf:type	hco:1q42.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3153,12 +3153,12 @@ hco:1q42.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	226800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3166,7 +3166,7 @@ hco:1q42.13
 	rdfs:label	"1q42.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q42.13#GRCh37
+hco:1q42.13\/GRCh37
 	rdf:type	hco:1q42.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3175,16 +3175,16 @@ hco:1q42.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	227000000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q42.13#GRCh38
+hco:1q42.13\/GRCh38
 	rdf:type	hco:1q42.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3193,12 +3193,12 @@ hco:1q42.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	226800000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3206,7 +3206,7 @@ hco:1q42.2
 	rdfs:label	"1q42.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q42.2#GRCh37
+hco:1q42.2\/GRCh37
 	rdf:type	hco:1q42.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -3215,16 +3215,16 @@ hco:1q42.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q42.2#GRCh38
+hco:1q42.2\/GRCh38
 	rdf:type	hco:1q42.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -3233,12 +3233,12 @@ hco:1q42.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3246,7 +3246,7 @@ hco:1q42.3
 	rdfs:label	"1q42.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q42.3#GRCh37
+hco:1q42.3\/GRCh37
 	rdf:type	hco:1q42.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3255,16 +3255,16 @@ hco:1q42.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q42.3#GRCh38
+hco:1q42.3\/GRCh38
 	rdf:type	hco:1q42.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3273,12 +3273,12 @@ hco:1q42.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234600000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3286,7 +3286,7 @@ hco:1q43
 	rdfs:label	"1q43" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q43#GRCh37
+hco:1q43\/GRCh37
 	rdf:type	hco:1q43 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3295,16 +3295,16 @@ hco:1q43#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236600000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	243700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q43#GRCh38
+hco:1q43\/GRCh38
 	rdf:type	hco:1q43 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3313,12 +3313,12 @@ hco:1q43#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236400000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	243500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3326,7 +3326,7 @@ hco:1q44
 	rdfs:label	"1q44" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:1q44#GRCh37
+hco:1q44\/GRCh37
 	rdf:type	hco:1q44 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3335,16 +3335,16 @@ hco:1q44#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	243700000 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	249250621 ;
-			faldo:reference	hco:1#GRCh37
+			faldo:reference	hco:1\/GRCh37
 		]
 	] .
 
-hco:1q44#GRCh38
+hco:1q44\/GRCh38
 	rdf:type	hco:1q44 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3353,12 +3353,12 @@ hco:1q44#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	243500000 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	248956422 ;
-			faldo:reference	hco:1#GRCh38
+			faldo:reference	hco:1\/GRCh38
 		]
 	] .
 
@@ -3366,7 +3366,7 @@ hco:10p15.3
 	rdfs:label	"10p15.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p15.3#GRCh37
+hco:10p15.3\/GRCh37
 	rdf:type	hco:10p15.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3375,16 +3375,16 @@ hco:10p15.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p15.3#GRCh38
+hco:10p15.3\/GRCh38
 	rdf:type	hco:10p15.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3393,12 +3393,12 @@ hco:10p15.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3406,7 +3406,7 @@ hco:10p15.2
 	rdfs:label	"10p15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p15.2#GRCh37
+hco:10p15.2\/GRCh37
 	rdf:type	hco:10p15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3415,16 +3415,16 @@ hco:10p15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p15.2#GRCh38
+hco:10p15.2\/GRCh38
 	rdf:type	hco:10p15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3433,12 +3433,12 @@ hco:10p15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3446,7 +3446,7 @@ hco:10p15.1
 	rdfs:label	"10p15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p15.1#GRCh37
+hco:10p15.1\/GRCh37
 	rdf:type	hco:10p15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3455,16 +3455,16 @@ hco:10p15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p15.1#GRCh38
+hco:10p15.1\/GRCh38
 	rdf:type	hco:10p15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3473,12 +3473,12 @@ hco:10p15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3486,7 +3486,7 @@ hco:10p14
 	rdfs:label	"10p14" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p14#GRCh37
+hco:10p14\/GRCh37
 	rdf:type	hco:10p14 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3495,16 +3495,16 @@ hco:10p14#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p14#GRCh38
+hco:10p14\/GRCh38
 	rdf:type	hco:10p14 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3513,12 +3513,12 @@ hco:10p14#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3526,7 +3526,7 @@ hco:10p13
 	rdfs:label	"10p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p13#GRCh37
+hco:10p13\/GRCh37
 	rdf:type	hco:10p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3535,16 +3535,16 @@ hco:10p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p13#GRCh38
+hco:10p13\/GRCh38
 	rdf:type	hco:10p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3553,12 +3553,12 @@ hco:10p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3566,7 +3566,7 @@ hco:10p12.33
 	rdfs:label	"10p12.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p12.33#GRCh37
+hco:10p12.33\/GRCh37
 	rdf:type	hco:10p12.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3575,16 +3575,16 @@ hco:10p12.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p12.33#GRCh38
+hco:10p12.33\/GRCh38
 	rdf:type	hco:10p12.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3593,12 +3593,12 @@ hco:10p12.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3606,7 +3606,7 @@ hco:10p12.32
 	rdfs:label	"10p12.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p12.32#GRCh37
+hco:10p12.32\/GRCh37
 	rdf:type	hco:10p12.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3615,16 +3615,16 @@ hco:10p12.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p12.32#GRCh38
+hco:10p12.32\/GRCh38
 	rdf:type	hco:10p12.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3633,12 +3633,12 @@ hco:10p12.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3646,7 +3646,7 @@ hco:10p12.31
 	rdfs:label	"10p12.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p12.31#GRCh37
+hco:10p12.31\/GRCh37
 	rdf:type	hco:10p12.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3655,16 +3655,16 @@ hco:10p12.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p12.31#GRCh38
+hco:10p12.31\/GRCh38
 	rdf:type	hco:10p12.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -3673,12 +3673,12 @@ hco:10p12.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3686,7 +3686,7 @@ hco:10p12.2
 	rdfs:label	"10p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p12.2#GRCh37
+hco:10p12.2\/GRCh37
 	rdf:type	hco:10p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3695,16 +3695,16 @@ hco:10p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p12.2#GRCh38
+hco:10p12.2\/GRCh38
 	rdf:type	hco:10p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3713,12 +3713,12 @@ hco:10p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3726,7 +3726,7 @@ hco:10p12.1
 	rdfs:label	"10p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p12.1#GRCh37
+hco:10p12.1\/GRCh37
 	rdf:type	hco:10p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -3735,16 +3735,16 @@ hco:10p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p12.1#GRCh38
+hco:10p12.1\/GRCh38
 	rdf:type	hco:10p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -3753,12 +3753,12 @@ hco:10p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3766,7 +3766,7 @@ hco:10p11.23
 	rdfs:label	"10p11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p11.23#GRCh37
+hco:10p11.23\/GRCh37
 	rdf:type	hco:10p11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3775,16 +3775,16 @@ hco:10p11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p11.23#GRCh38
+hco:10p11.23\/GRCh38
 	rdf:type	hco:10p11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3793,12 +3793,12 @@ hco:10p11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3806,7 +3806,7 @@ hco:10p11.22
 	rdfs:label	"10p11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p11.22#GRCh37
+hco:10p11.22\/GRCh37
 	rdf:type	hco:10p11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3815,16 +3815,16 @@ hco:10p11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p11.22#GRCh38
+hco:10p11.22\/GRCh38
 	rdf:type	hco:10p11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -3833,12 +3833,12 @@ hco:10p11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3846,7 +3846,7 @@ hco:10p11.21
 	rdfs:label	"10p11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p11.21#GRCh37
+hco:10p11.21\/GRCh37
 	rdf:type	hco:10p11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3855,16 +3855,16 @@ hco:10p11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p11.21#GRCh38
+hco:10p11.21\/GRCh38
 	rdf:type	hco:10p11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3873,12 +3873,12 @@ hco:10p11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3886,7 +3886,7 @@ hco:10p11.1
 	rdfs:label	"10p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10p11.1#GRCh37
+hco:10p11.1\/GRCh37
 	rdf:type	hco:10p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -3895,16 +3895,16 @@ hco:10p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10p11.1#GRCh38
+hco:10p11.1\/GRCh38
 	rdf:type	hco:10p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -3913,12 +3913,12 @@ hco:10p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3926,7 +3926,7 @@ hco:10q11.1
 	rdfs:label	"10q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q11.1#GRCh37
+hco:10q11.1\/GRCh37
 	rdf:type	hco:10q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -3935,16 +3935,16 @@ hco:10q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q11.1#GRCh38
+hco:10q11.1\/GRCh38
 	rdf:type	hco:10q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -3953,12 +3953,12 @@ hco:10q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -3966,7 +3966,7 @@ hco:10q11.21
 	rdfs:label	"10q11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q11.21#GRCh37
+hco:10q11.21\/GRCh37
 	rdf:type	hco:10q11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -3975,16 +3975,16 @@ hco:10q11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q11.21#GRCh38
+hco:10q11.21\/GRCh38
 	rdf:type	hco:10q11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -3993,12 +3993,12 @@ hco:10q11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45500000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4006,7 +4006,7 @@ hco:10q11.22
 	rdfs:label	"10q11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q11.22#GRCh37
+hco:10q11.22\/GRCh37
 	rdf:type	hco:10q11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -4015,16 +4015,16 @@ hco:10q11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q11.22#GRCh38
+hco:10q11.22\/GRCh38
 	rdf:type	hco:10q11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -4033,12 +4033,12 @@ hco:10q11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45500000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4046,7 +4046,7 @@ hco:10q11.23
 	rdfs:label	"10q11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q11.23#GRCh37
+hco:10q11.23\/GRCh37
 	rdf:type	hco:10q11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4055,16 +4055,16 @@ hco:10q11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q11.23#GRCh38
+hco:10q11.23\/GRCh38
 	rdf:type	hco:10q11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4073,12 +4073,12 @@ hco:10q11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48600000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4086,7 +4086,7 @@ hco:10q21.1
 	rdfs:label	"10q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q21.1#GRCh37
+hco:10q21.1\/GRCh37
 	rdf:type	hco:10q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4095,16 +4095,16 @@ hco:10q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q21.1#GRCh38
+hco:10q21.1\/GRCh38
 	rdf:type	hco:10q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4113,12 +4113,12 @@ hco:10q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4126,7 +4126,7 @@ hco:10q21.2
 	rdfs:label	"10q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q21.2#GRCh37
+hco:10q21.2\/GRCh37
 	rdf:type	hco:10q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4135,16 +4135,16 @@ hco:10q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61200000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q21.2#GRCh38
+hco:10q21.2\/GRCh38
 	rdf:type	hco:10q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4153,12 +4153,12 @@ hco:10q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4166,7 +4166,7 @@ hco:10q21.3
 	rdfs:label	"10q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q21.3#GRCh37
+hco:10q21.3\/GRCh37
 	rdf:type	hco:10q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4175,16 +4175,16 @@ hco:10q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q21.3#GRCh38
+hco:10q21.3\/GRCh38
 	rdf:type	hco:10q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4193,12 +4193,12 @@ hco:10q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4206,7 +4206,7 @@ hco:10q22.1
 	rdfs:label	"10q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q22.1#GRCh37
+hco:10q22.1\/GRCh37
 	rdf:type	hco:10q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4215,16 +4215,16 @@ hco:10q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q22.1#GRCh38
+hco:10q22.1\/GRCh38
 	rdf:type	hco:10q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4233,12 +4233,12 @@ hco:10q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4246,7 +4246,7 @@ hco:10q22.2
 	rdfs:label	"10q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q22.2#GRCh37
+hco:10q22.2\/GRCh37
 	rdf:type	hco:10q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4255,16 +4255,16 @@ hco:10q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q22.2#GRCh38
+hco:10q22.2\/GRCh38
 	rdf:type	hco:10q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4273,12 +4273,12 @@ hco:10q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75900000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4286,7 +4286,7 @@ hco:10q22.3
 	rdfs:label	"10q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q22.3#GRCh37
+hco:10q22.3\/GRCh37
 	rdf:type	hco:10q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4295,16 +4295,16 @@ hco:10q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q22.3#GRCh38
+hco:10q22.3\/GRCh38
 	rdf:type	hco:10q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4313,12 +4313,12 @@ hco:10q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75900000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4326,7 +4326,7 @@ hco:10q23.1
 	rdfs:label	"10q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q23.1#GRCh37
+hco:10q23.1\/GRCh37
 	rdf:type	hco:10q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4335,16 +4335,16 @@ hco:10q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q23.1#GRCh38
+hco:10q23.1\/GRCh38
 	rdf:type	hco:10q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4353,12 +4353,12 @@ hco:10q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4366,7 +4366,7 @@ hco:10q23.2
 	rdfs:label	"10q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q23.2#GRCh37
+hco:10q23.2\/GRCh37
 	rdf:type	hco:10q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4375,16 +4375,16 @@ hco:10q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q23.2#GRCh38
+hco:10q23.2\/GRCh38
 	rdf:type	hco:10q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4393,12 +4393,12 @@ hco:10q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87700000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4406,7 +4406,7 @@ hco:10q23.31
 	rdfs:label	"10q23.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q23.31#GRCh37
+hco:10q23.31\/GRCh37
 	rdf:type	hco:10q23.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -4415,16 +4415,16 @@ hco:10q23.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q23.31#GRCh38
+hco:10q23.31\/GRCh38
 	rdf:type	hco:10q23.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -4433,12 +4433,12 @@ hco:10q23.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87700000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4446,7 +4446,7 @@ hco:10q23.32
 	rdfs:label	"10q23.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q23.32#GRCh37
+hco:10q23.32\/GRCh37
 	rdf:type	hco:10q23.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4455,16 +4455,16 @@ hco:10q23.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q23.32#GRCh38
+hco:10q23.32\/GRCh38
 	rdf:type	hco:10q23.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4473,12 +4473,12 @@ hco:10q23.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4486,7 +4486,7 @@ hco:10q23.33
 	rdfs:label	"10q23.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q23.33#GRCh37
+hco:10q23.33\/GRCh37
 	rdf:type	hco:10q23.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4495,16 +4495,16 @@ hco:10q23.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q23.33#GRCh38
+hco:10q23.33\/GRCh38
 	rdf:type	hco:10q23.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4513,12 +4513,12 @@ hco:10q23.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4526,7 +4526,7 @@ hco:10q24.1
 	rdfs:label	"10q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q24.1#GRCh37
+hco:10q24.1\/GRCh37
 	rdf:type	hco:10q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4535,16 +4535,16 @@ hco:10q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q24.1#GRCh38
+hco:10q24.1\/GRCh38
 	rdf:type	hco:10q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4553,12 +4553,12 @@ hco:10q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97500000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4566,7 +4566,7 @@ hco:10q24.2
 	rdfs:label	"10q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q24.2#GRCh37
+hco:10q24.2\/GRCh37
 	rdf:type	hco:10q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4575,16 +4575,16 @@ hco:10q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q24.2#GRCh38
+hco:10q24.2\/GRCh38
 	rdf:type	hco:10q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4593,12 +4593,12 @@ hco:10q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97500000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4606,7 +4606,7 @@ hco:10q24.31
 	rdfs:label	"10q24.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q24.31#GRCh37
+hco:10q24.31\/GRCh37
 	rdf:type	hco:10q24.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4615,16 +4615,16 @@ hco:10q24.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q24.31#GRCh38
+hco:10q24.31\/GRCh38
 	rdf:type	hco:10q24.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4633,12 +4633,12 @@ hco:10q24.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4646,7 +4646,7 @@ hco:10q24.32
 	rdfs:label	"10q24.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q24.32#GRCh37
+hco:10q24.32\/GRCh37
 	rdf:type	hco:10q24.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -4655,16 +4655,16 @@ hco:10q24.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103000000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q24.32#GRCh38
+hco:10q24.32\/GRCh38
 	rdf:type	hco:10q24.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -4673,12 +4673,12 @@ hco:10q24.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4686,7 +4686,7 @@ hco:10q24.33
 	rdfs:label	"10q24.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q24.33#GRCh37
+hco:10q24.33\/GRCh37
 	rdf:type	hco:10q24.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4695,16 +4695,16 @@ hco:10q24.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105800000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q24.33#GRCh38
+hco:10q24.33\/GRCh38
 	rdf:type	hco:10q24.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4713,12 +4713,12 @@ hco:10q24.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4726,7 +4726,7 @@ hco:10q25.1
 	rdfs:label	"10q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q25.1#GRCh37
+hco:10q25.1\/GRCh37
 	rdf:type	hco:10q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4735,16 +4735,16 @@ hco:10q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105800000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q25.1#GRCh38
+hco:10q25.1\/GRCh38
 	rdf:type	hco:10q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -4753,12 +4753,12 @@ hco:10q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104000000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4766,7 +4766,7 @@ hco:10q25.2
 	rdfs:label	"10q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q25.2#GRCh37
+hco:10q25.2\/GRCh37
 	rdf:type	hco:10q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4775,16 +4775,16 @@ hco:10q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q25.2#GRCh38
+hco:10q25.2\/GRCh38
 	rdf:type	hco:10q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4793,12 +4793,12 @@ hco:10q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4806,7 +4806,7 @@ hco:10q25.3
 	rdfs:label	"10q25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q25.3#GRCh37
+hco:10q25.3\/GRCh37
 	rdf:type	hco:10q25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -4815,16 +4815,16 @@ hco:10q25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q25.3#GRCh38
+hco:10q25.3\/GRCh38
 	rdf:type	hco:10q25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -4833,12 +4833,12 @@ hco:10q25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113100000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4846,7 +4846,7 @@ hco:10q26.11
 	rdfs:label	"10q26.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q26.11#GRCh37
+hco:10q26.11\/GRCh37
 	rdf:type	hco:10q26.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4855,16 +4855,16 @@ hco:10q26.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q26.11#GRCh38
+hco:10q26.11\/GRCh38
 	rdf:type	hco:10q26.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4873,12 +4873,12 @@ hco:10q26.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117300000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119900000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4886,7 +4886,7 @@ hco:10q26.12
 	rdfs:label	"10q26.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q26.12#GRCh37
+hco:10q26.12\/GRCh37
 	rdf:type	hco:10q26.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4895,16 +4895,16 @@ hco:10q26.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121700000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q26.12#GRCh38
+hco:10q26.12\/GRCh38
 	rdf:type	hco:10q26.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4913,12 +4913,12 @@ hco:10q26.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119900000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4926,7 +4926,7 @@ hco:10q26.13
 	rdfs:label	"10q26.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q26.13#GRCh37
+hco:10q26.13\/GRCh37
 	rdf:type	hco:10q26.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -4935,16 +4935,16 @@ hco:10q26.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123100000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q26.13#GRCh38
+hco:10q26.13\/GRCh38
 	rdf:type	hco:10q26.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -4953,12 +4953,12 @@ hco:10q26.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125700000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -4966,7 +4966,7 @@ hco:10q26.2
 	rdfs:label	"10q26.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q26.2#GRCh37
+hco:10q26.2\/GRCh37
 	rdf:type	hco:10q26.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4975,16 +4975,16 @@ hco:10q26.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q26.2#GRCh38
+hco:10q26.2\/GRCh38
 	rdf:type	hco:10q26.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -4993,12 +4993,12 @@ hco:10q26.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125700000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -5006,7 +5006,7 @@ hco:10q26.3
 	rdfs:label	"10q26.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:10q26.3#GRCh37
+hco:10q26.3\/GRCh37
 	rdf:type	hco:10q26.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5015,16 +5015,16 @@ hco:10q26.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135534747 ;
-			faldo:reference	hco:10#GRCh37
+			faldo:reference	hco:10\/GRCh37
 		]
 	] .
 
-hco:10q26.3#GRCh38
+hco:10q26.3\/GRCh38
 	rdf:type	hco:10q26.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5033,12 +5033,12 @@ hco:10q26.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128800000 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133797422 ;
-			faldo:reference	hco:10#GRCh38
+			faldo:reference	hco:10\/GRCh38
 		]
 	] .
 
@@ -5046,7 +5046,7 @@ hco:11p15.5
 	rdfs:label	"11p15.5" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p15.5#GRCh37
+hco:11p15.5\/GRCh37
 	rdf:type	hco:11p15.5 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5055,16 +5055,16 @@ hco:11p15.5#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p15.5#GRCh38
+hco:11p15.5\/GRCh38
 	rdf:type	hco:11p15.5 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5073,12 +5073,12 @@ hco:11p15.5#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5086,7 +5086,7 @@ hco:11p15.4
 	rdfs:label	"11p15.4" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p15.4#GRCh37
+hco:11p15.4\/GRCh37
 	rdf:type	hco:11p15.4 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5095,16 +5095,16 @@ hco:11p15.4#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p15.4#GRCh38
+hco:11p15.4\/GRCh38
 	rdf:type	hco:11p15.4 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5113,12 +5113,12 @@ hco:11p15.4#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5126,7 +5126,7 @@ hco:11p15.3
 	rdfs:label	"11p15.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p15.3#GRCh37
+hco:11p15.3\/GRCh37
 	rdf:type	hco:11p15.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5135,16 +5135,16 @@ hco:11p15.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p15.3#GRCh38
+hco:11p15.3\/GRCh38
 	rdf:type	hco:11p15.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5153,12 +5153,12 @@ hco:11p15.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5166,7 +5166,7 @@ hco:11p15.2
 	rdfs:label	"11p15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p15.2#GRCh37
+hco:11p15.2\/GRCh37
 	rdf:type	hco:11p15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5175,16 +5175,16 @@ hco:11p15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p15.2#GRCh38
+hco:11p15.2\/GRCh38
 	rdf:type	hco:11p15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5193,12 +5193,12 @@ hco:11p15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5206,7 +5206,7 @@ hco:11p15.1
 	rdfs:label	"11p15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p15.1#GRCh37
+hco:11p15.1\/GRCh37
 	rdf:type	hco:11p15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5215,16 +5215,16 @@ hco:11p15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p15.1#GRCh38
+hco:11p15.1\/GRCh38
 	rdf:type	hco:11p15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5233,12 +5233,12 @@ hco:11p15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5246,7 +5246,7 @@ hco:11p14.3
 	rdfs:label	"11p14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p14.3#GRCh37
+hco:11p14.3\/GRCh37
 	rdf:type	hco:11p14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5255,16 +5255,16 @@ hco:11p14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p14.3#GRCh38
+hco:11p14.3\/GRCh38
 	rdf:type	hco:11p14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5273,12 +5273,12 @@ hco:11p14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5286,7 +5286,7 @@ hco:11p14.2
 	rdfs:label	"11p14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p14.2#GRCh37
+hco:11p14.2\/GRCh37
 	rdf:type	hco:11p14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5295,16 +5295,16 @@ hco:11p14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p14.2#GRCh38
+hco:11p14.2\/GRCh38
 	rdf:type	hco:11p14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5313,12 +5313,12 @@ hco:11p14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5326,7 +5326,7 @@ hco:11p14.1
 	rdfs:label	"11p14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p14.1#GRCh37
+hco:11p14.1\/GRCh37
 	rdf:type	hco:11p14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5335,16 +5335,16 @@ hco:11p14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31000000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p14.1#GRCh38
+hco:11p14.1\/GRCh38
 	rdf:type	hco:11p14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5353,12 +5353,12 @@ hco:11p14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5366,7 +5366,7 @@ hco:11p13
 	rdfs:label	"11p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p13#GRCh37
+hco:11p13\/GRCh37
 	rdf:type	hco:11p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5375,16 +5375,16 @@ hco:11p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31000000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p13#GRCh38
+hco:11p13\/GRCh38
 	rdf:type	hco:11p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5393,12 +5393,12 @@ hco:11p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5406,7 +5406,7 @@ hco:11p12
 	rdfs:label	"11p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p12#GRCh37
+hco:11p12\/GRCh37
 	rdf:type	hco:11p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5415,16 +5415,16 @@ hco:11p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p12#GRCh38
+hco:11p12\/GRCh38
 	rdf:type	hco:11p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5433,12 +5433,12 @@ hco:11p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5446,7 +5446,7 @@ hco:11p11.2
 	rdfs:label	"11p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p11.2#GRCh37
+hco:11p11.2\/GRCh37
 	rdf:type	hco:11p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5455,16 +5455,16 @@ hco:11p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p11.2#GRCh38
+hco:11p11.2\/GRCh38
 	rdf:type	hco:11p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5473,12 +5473,12 @@ hco:11p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5486,7 +5486,7 @@ hco:11p11.12
 	rdfs:label	"11p11.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p11.12#GRCh37
+hco:11p11.12\/GRCh37
 	rdf:type	hco:11p11.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5495,16 +5495,16 @@ hco:11p11.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51600000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p11.12#GRCh38
+hco:11p11.12\/GRCh38
 	rdf:type	hco:11p11.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5513,12 +5513,12 @@ hco:11p11.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5526,7 +5526,7 @@ hco:11p11.11
 	rdfs:label	"11p11.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11p11.11#GRCh37
+hco:11p11.11\/GRCh37
 	rdf:type	hco:11p11.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -5535,16 +5535,16 @@ hco:11p11.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51600000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11p11.11#GRCh38
+hco:11p11.11\/GRCh38
 	rdf:type	hco:11p11.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -5553,12 +5553,12 @@ hco:11p11.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5566,7 +5566,7 @@ hco:11q11
 	rdfs:label	"11q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q11#GRCh37
+hco:11q11\/GRCh37
 	rdf:type	hco:11q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -5575,16 +5575,16 @@ hco:11q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q11#GRCh38
+hco:11q11\/GRCh38
 	rdf:type	hco:11q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -5593,12 +5593,12 @@ hco:11q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5606,7 +5606,7 @@ hco:11q12.1
 	rdfs:label	"11q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q12.1#GRCh37
+hco:11q12.1\/GRCh37
 	rdf:type	hco:11q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5615,16 +5615,16 @@ hco:11q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q12.1#GRCh38
+hco:11q12.1\/GRCh38
 	rdf:type	hco:11q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -5633,12 +5633,12 @@ hco:11q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55800000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60100000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5646,7 +5646,7 @@ hco:11q12.2
 	rdfs:label	"11q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q12.2#GRCh37
+hco:11q12.2\/GRCh37
 	rdf:type	hco:11q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5655,16 +5655,16 @@ hco:11q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q12.2#GRCh38
+hco:11q12.2\/GRCh38
 	rdf:type	hco:11q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5673,12 +5673,12 @@ hco:11q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60100000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5686,7 +5686,7 @@ hco:11q12.3
 	rdfs:label	"11q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q12.3#GRCh37
+hco:11q12.3\/GRCh37
 	rdf:type	hco:11q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -5695,16 +5695,16 @@ hco:11q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61700000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q12.3#GRCh38
+hco:11q12.3\/GRCh38
 	rdf:type	hco:11q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -5713,12 +5713,12 @@ hco:11q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5726,7 +5726,7 @@ hco:11q13.1
 	rdfs:label	"11q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q13.1#GRCh37
+hco:11q13.1\/GRCh37
 	rdf:type	hco:11q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5735,16 +5735,16 @@ hco:11q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q13.1#GRCh38
+hco:11q13.1\/GRCh38
 	rdf:type	hco:11q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5753,12 +5753,12 @@ hco:11q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66100000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5766,7 +5766,7 @@ hco:11q13.2
 	rdfs:label	"11q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q13.2#GRCh37
+hco:11q13.2\/GRCh37
 	rdf:type	hco:11q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -5775,16 +5775,16 @@ hco:11q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q13.2#GRCh38
+hco:11q13.2\/GRCh38
 	rdf:type	hco:11q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -5793,12 +5793,12 @@ hco:11q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66100000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5806,7 +5806,7 @@ hco:11q13.3
 	rdfs:label	"11q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q13.3#GRCh37
+hco:11q13.3\/GRCh37
 	rdf:type	hco:11q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5815,16 +5815,16 @@ hco:11q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q13.3#GRCh38
+hco:11q13.3\/GRCh38
 	rdf:type	hco:11q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5833,12 +5833,12 @@ hco:11q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5846,7 +5846,7 @@ hco:11q13.4
 	rdfs:label	"11q13.4" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q13.4#GRCh37
+hco:11q13.4\/GRCh37
 	rdf:type	hco:11q13.4 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5855,16 +5855,16 @@ hco:11q13.4#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q13.4#GRCh38
+hco:11q13.4\/GRCh38
 	rdf:type	hco:11q13.4 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -5873,12 +5873,12 @@ hco:11q13.4#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75500000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5886,7 +5886,7 @@ hco:11q13.5
 	rdfs:label	"11q13.5" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q13.5#GRCh37
+hco:11q13.5\/GRCh37
 	rdf:type	hco:11q13.5 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5895,16 +5895,16 @@ hco:11q13.5#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q13.5#GRCh38
+hco:11q13.5\/GRCh38
 	rdf:type	hco:11q13.5 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5913,12 +5913,12 @@ hco:11q13.5#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75500000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5926,7 +5926,7 @@ hco:11q14.1
 	rdfs:label	"11q14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q14.1#GRCh37
+hco:11q14.1\/GRCh37
 	rdf:type	hco:11q14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5935,16 +5935,16 @@ hco:11q14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85600000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q14.1#GRCh38
+hco:11q14.1\/GRCh38
 	rdf:type	hco:11q14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -5953,12 +5953,12 @@ hco:11q14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -5966,7 +5966,7 @@ hco:11q14.2
 	rdfs:label	"11q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q14.2#GRCh37
+hco:11q14.2\/GRCh37
 	rdf:type	hco:11q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -5975,16 +5975,16 @@ hco:11q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85600000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88300000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q14.2#GRCh38
+hco:11q14.2\/GRCh38
 	rdf:type	hco:11q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -5993,12 +5993,12 @@ hco:11q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6006,7 +6006,7 @@ hco:11q14.3
 	rdfs:label	"11q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q14.3#GRCh37
+hco:11q14.3\/GRCh37
 	rdf:type	hco:11q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6015,16 +6015,16 @@ hco:11q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88300000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q14.3#GRCh38
+hco:11q14.3\/GRCh38
 	rdf:type	hco:11q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6033,12 +6033,12 @@ hco:11q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6046,7 +6046,7 @@ hco:11q21
 	rdfs:label	"11q21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q21#GRCh37
+hco:11q21\/GRCh37
 	rdf:type	hco:11q21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6055,16 +6055,16 @@ hco:11q21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q21#GRCh38
+hco:11q21\/GRCh38
 	rdf:type	hco:11q21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6073,12 +6073,12 @@ hco:11q21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6086,7 +6086,7 @@ hco:11q22.1
 	rdfs:label	"11q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q22.1#GRCh37
+hco:11q22.1\/GRCh37
 	rdf:type	hco:11q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6095,16 +6095,16 @@ hco:11q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q22.1#GRCh38
+hco:11q22.1\/GRCh38
 	rdf:type	hco:11q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6113,12 +6113,12 @@ hco:11q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97400000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102300000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6126,7 +6126,7 @@ hco:11q22.2
 	rdfs:label	"11q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q22.2#GRCh37
+hco:11q22.2\/GRCh37
 	rdf:type	hco:11q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6135,16 +6135,16 @@ hco:11q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102100000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q22.2#GRCh38
+hco:11q22.2\/GRCh38
 	rdf:type	hco:11q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6153,12 +6153,12 @@ hco:11q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102300000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6166,7 +6166,7 @@ hco:11q22.3
 	rdfs:label	"11q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q22.3#GRCh37
+hco:11q22.3\/GRCh37
 	rdf:type	hco:11q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6175,16 +6175,16 @@ hco:11q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q22.3#GRCh38
+hco:11q22.3\/GRCh38
 	rdf:type	hco:11q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6193,12 +6193,12 @@ hco:11q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6206,7 +6206,7 @@ hco:11q23.1
 	rdfs:label	"11q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q23.1#GRCh37
+hco:11q23.1\/GRCh37
 	rdf:type	hco:11q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6215,16 +6215,16 @@ hco:11q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110400000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q23.1#GRCh38
+hco:11q23.1\/GRCh38
 	rdf:type	hco:11q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6233,12 +6233,12 @@ hco:11q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6246,7 +6246,7 @@ hco:11q23.2
 	rdfs:label	"11q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q23.2#GRCh37
+hco:11q23.2\/GRCh37
 	rdf:type	hco:11q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6255,16 +6255,16 @@ hco:11q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q23.2#GRCh38
+hco:11q23.2\/GRCh38
 	rdf:type	hco:11q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6273,12 +6273,12 @@ hco:11q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112700000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6286,7 +6286,7 @@ hco:11q23.3
 	rdfs:label	"11q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q23.3#GRCh37
+hco:11q23.3\/GRCh37
 	rdf:type	hco:11q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6295,16 +6295,16 @@ hco:11q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114500000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q23.3#GRCh38
+hco:11q23.3\/GRCh38
 	rdf:type	hco:11q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6313,12 +6313,12 @@ hco:11q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121300000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6326,7 +6326,7 @@ hco:11q24.1
 	rdfs:label	"11q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q24.1#GRCh37
+hco:11q24.1\/GRCh37
 	rdf:type	hco:11q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6335,16 +6335,16 @@ hco:11q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121200000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q24.1#GRCh38
+hco:11q24.1\/GRCh38
 	rdf:type	hco:11q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6353,12 +6353,12 @@ hco:11q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121300000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6366,7 +6366,7 @@ hco:11q24.2
 	rdfs:label	"11q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q24.2#GRCh37
+hco:11q24.2\/GRCh37
 	rdf:type	hco:11q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6375,16 +6375,16 @@ hco:11q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123900000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q24.2#GRCh38
+hco:11q24.2\/GRCh38
 	rdf:type	hco:11q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6393,12 +6393,12 @@ hco:11q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124000000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6406,7 +6406,7 @@ hco:11q24.3
 	rdfs:label	"11q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q24.3#GRCh37
+hco:11q24.3\/GRCh37
 	rdf:type	hco:11q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6415,16 +6415,16 @@ hco:11q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q24.3#GRCh38
+hco:11q24.3\/GRCh38
 	rdf:type	hco:11q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6433,12 +6433,12 @@ hco:11q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6446,7 +6446,7 @@ hco:11q25
 	rdfs:label	"11q25" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:11q25#GRCh37
+hco:11q25\/GRCh37
 	rdf:type	hco:11q25 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6455,16 +6455,16 @@ hco:11q25#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130800000 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135006516 ;
-			faldo:reference	hco:11#GRCh37
+			faldo:reference	hco:11\/GRCh37
 		]
 	] .
 
-hco:11q25#GRCh38
+hco:11q25\/GRCh38
 	rdf:type	hco:11q25 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6473,12 +6473,12 @@ hco:11q25#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130900000 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135086622 ;
-			faldo:reference	hco:11#GRCh38
+			faldo:reference	hco:11\/GRCh38
 		]
 	] .
 
@@ -6486,7 +6486,7 @@ hco:12p13.33
 	rdfs:label	"12p13.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p13.33#GRCh37
+hco:12p13.33\/GRCh37
 	rdf:type	hco:12p13.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6495,16 +6495,16 @@ hco:12p13.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p13.33#GRCh38
+hco:12p13.33\/GRCh38
 	rdf:type	hco:12p13.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6513,12 +6513,12 @@ hco:12p13.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6526,7 +6526,7 @@ hco:12p13.32
 	rdfs:label	"12p13.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p13.32#GRCh37
+hco:12p13.32\/GRCh37
 	rdf:type	hco:12p13.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -6535,16 +6535,16 @@ hco:12p13.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5400000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p13.32#GRCh38
+hco:12p13.32\/GRCh38
 	rdf:type	hco:12p13.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -6553,12 +6553,12 @@ hco:12p13.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6566,7 +6566,7 @@ hco:12p13.31
 	rdfs:label	"12p13.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p13.31#GRCh37
+hco:12p13.31\/GRCh37
 	rdf:type	hco:12p13.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6575,16 +6575,16 @@ hco:12p13.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5400000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p13.31#GRCh38
+hco:12p13.31\/GRCh38
 	rdf:type	hco:12p13.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6593,12 +6593,12 @@ hco:12p13.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10000000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6606,7 +6606,7 @@ hco:12p13.2
 	rdfs:label	"12p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p13.2#GRCh37
+hco:12p13.2\/GRCh37
 	rdf:type	hco:12p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -6615,16 +6615,16 @@ hco:12p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p13.2#GRCh38
+hco:12p13.2\/GRCh38
 	rdf:type	hco:12p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -6633,12 +6633,12 @@ hco:12p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10000000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6646,7 +6646,7 @@ hco:12p13.1
 	rdfs:label	"12p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p13.1#GRCh37
+hco:12p13.1\/GRCh37
 	rdf:type	hco:12p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6655,16 +6655,16 @@ hco:12p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p13.1#GRCh38
+hco:12p13.1\/GRCh38
 	rdf:type	hco:12p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6673,12 +6673,12 @@ hco:12p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6686,7 +6686,7 @@ hco:12p12.3
 	rdfs:label	"12p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p12.3#GRCh37
+hco:12p12.3\/GRCh37
 	rdf:type	hco:12p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6695,16 +6695,16 @@ hco:12p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p12.3#GRCh38
+hco:12p12.3\/GRCh38
 	rdf:type	hco:12p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6713,12 +6713,12 @@ hco:12p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6726,7 +6726,7 @@ hco:12p12.2
 	rdfs:label	"12p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p12.2#GRCh37
+hco:12p12.2\/GRCh37
 	rdf:type	hco:12p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6735,16 +6735,16 @@ hco:12p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p12.2#GRCh38
+hco:12p12.2\/GRCh38
 	rdf:type	hco:12p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6753,12 +6753,12 @@ hco:12p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6766,7 +6766,7 @@ hco:12p12.1
 	rdfs:label	"12p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p12.1#GRCh37
+hco:12p12.1\/GRCh37
 	rdf:type	hco:12p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6775,16 +6775,16 @@ hco:12p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p12.1#GRCh38
+hco:12p12.1\/GRCh38
 	rdf:type	hco:12p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -6793,12 +6793,12 @@ hco:12p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6806,7 +6806,7 @@ hco:12p11.23
 	rdfs:label	"12p11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p11.23#GRCh37
+hco:12p11.23\/GRCh37
 	rdf:type	hco:12p11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6815,16 +6815,16 @@ hco:12p11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p11.23#GRCh38
+hco:12p11.23\/GRCh38
 	rdf:type	hco:12p11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6833,12 +6833,12 @@ hco:12p11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6846,7 +6846,7 @@ hco:12p11.22
 	rdfs:label	"12p11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p11.22#GRCh37
+hco:12p11.22\/GRCh37
 	rdf:type	hco:12p11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6855,16 +6855,16 @@ hco:12p11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p11.22#GRCh38
+hco:12p11.22\/GRCh38
 	rdf:type	hco:12p11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -6873,12 +6873,12 @@ hco:12p11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6886,7 +6886,7 @@ hco:12p11.21
 	rdfs:label	"12p11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p11.21#GRCh37
+hco:12p11.21\/GRCh37
 	rdf:type	hco:12p11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -6895,16 +6895,16 @@ hco:12p11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p11.21#GRCh38
+hco:12p11.21\/GRCh38
 	rdf:type	hco:12p11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -6913,12 +6913,12 @@ hco:12p11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6926,7 +6926,7 @@ hco:12p11.1
 	rdfs:label	"12p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12p11.1#GRCh37
+hco:12p11.1\/GRCh37
 	rdf:type	hco:12p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -6935,16 +6935,16 @@ hco:12p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12p11.1#GRCh38
+hco:12p11.1\/GRCh38
 	rdf:type	hco:12p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -6953,12 +6953,12 @@ hco:12p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -6966,7 +6966,7 @@ hco:12q11
 	rdfs:label	"12q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q11#GRCh37
+hco:12q11\/GRCh37
 	rdf:type	hco:12q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -6975,16 +6975,16 @@ hco:12q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38200000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q11#GRCh38
+hco:12q11\/GRCh38
 	rdf:type	hco:12q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -6993,12 +6993,12 @@ hco:12q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7006,7 +7006,7 @@ hco:12q12
 	rdfs:label	"12q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q12#GRCh37
+hco:12q12\/GRCh37
 	rdf:type	hco:12q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7015,16 +7015,16 @@ hco:12q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38200000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q12#GRCh38
+hco:12q12\/GRCh38
 	rdf:type	hco:12q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7033,12 +7033,12 @@ hco:12q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46000000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7046,7 +7046,7 @@ hco:12q13.11
 	rdfs:label	"12q13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q13.11#GRCh37
+hco:12q13.11\/GRCh37
 	rdf:type	hco:12q13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7055,16 +7055,16 @@ hco:12q13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q13.11#GRCh38
+hco:12q13.11\/GRCh38
 	rdf:type	hco:12q13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7073,12 +7073,12 @@ hco:12q13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46000000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7086,7 +7086,7 @@ hco:12q13.12
 	rdfs:label	"12q13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q13.12#GRCh37
+hco:12q13.12\/GRCh37
 	rdf:type	hco:12q13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7095,16 +7095,16 @@ hco:12q13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q13.12#GRCh38
+hco:12q13.12\/GRCh38
 	rdf:type	hco:12q13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7113,12 +7113,12 @@ hco:12q13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7126,7 +7126,7 @@ hco:12q13.13
 	rdfs:label	"12q13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q13.13#GRCh37
+hco:12q13.13\/GRCh37
 	rdf:type	hco:12q13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7135,16 +7135,16 @@ hco:12q13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54900000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q13.13#GRCh38
+hco:12q13.13\/GRCh38
 	rdf:type	hco:12q13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7153,12 +7153,12 @@ hco:12q13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7166,7 +7166,7 @@ hco:12q13.2
 	rdfs:label	"12q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q13.2#GRCh37
+hco:12q13.2\/GRCh37
 	rdf:type	hco:12q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7175,16 +7175,16 @@ hco:12q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54900000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q13.2#GRCh38
+hco:12q13.2\/GRCh38
 	rdf:type	hco:12q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7193,12 +7193,12 @@ hco:12q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7206,7 +7206,7 @@ hco:12q13.3
 	rdfs:label	"12q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q13.3#GRCh37
+hco:12q13.3\/GRCh37
 	rdf:type	hco:12q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7215,16 +7215,16 @@ hco:12q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q13.3#GRCh38
+hco:12q13.3\/GRCh38
 	rdf:type	hco:12q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7233,12 +7233,12 @@ hco:12q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7246,7 +7246,7 @@ hco:12q14.1
 	rdfs:label	"12q14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q14.1#GRCh37
+hco:12q14.1\/GRCh37
 	rdf:type	hco:12q14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7255,16 +7255,16 @@ hco:12q14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q14.1#GRCh38
+hco:12q14.1\/GRCh38
 	rdf:type	hco:12q14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7273,12 +7273,12 @@ hco:12q14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7286,7 +7286,7 @@ hco:12q14.2
 	rdfs:label	"12q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q14.2#GRCh37
+hco:12q14.2\/GRCh37
 	rdf:type	hco:12q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7295,16 +7295,16 @@ hco:12q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q14.2#GRCh38
+hco:12q14.2\/GRCh38
 	rdf:type	hco:12q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7313,12 +7313,12 @@ hco:12q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7326,7 +7326,7 @@ hco:12q14.3
 	rdfs:label	"12q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q14.3#GRCh37
+hco:12q14.3\/GRCh37
 	rdf:type	hco:12q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7335,16 +7335,16 @@ hco:12q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q14.3#GRCh38
+hco:12q14.3\/GRCh38
 	rdf:type	hco:12q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7353,12 +7353,12 @@ hco:12q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7366,7 +7366,7 @@ hco:12q15
 	rdfs:label	"12q15" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q15#GRCh37
+hco:12q15\/GRCh37
 	rdf:type	hco:12q15 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7375,16 +7375,16 @@ hco:12q15#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q15#GRCh38
+hco:12q15\/GRCh38
 	rdf:type	hco:12q15 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7393,12 +7393,12 @@ hco:12q15#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7406,7 +7406,7 @@ hco:12q21.1
 	rdfs:label	"12q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q21.1#GRCh37
+hco:12q21.1\/GRCh37
 	rdf:type	hco:12q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7415,16 +7415,16 @@ hco:12q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71500000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q21.1#GRCh38
+hco:12q21.1\/GRCh38
 	rdf:type	hco:12q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7433,12 +7433,12 @@ hco:12q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71100000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7446,7 +7446,7 @@ hco:12q21.2
 	rdfs:label	"12q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q21.2#GRCh37
+hco:12q21.2\/GRCh37
 	rdf:type	hco:12q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7455,16 +7455,16 @@ hco:12q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q21.2#GRCh38
+hco:12q21.2\/GRCh38
 	rdf:type	hco:12q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7473,12 +7473,12 @@ hco:12q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7486,7 +7486,7 @@ hco:12q21.31
 	rdfs:label	"12q21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q21.31#GRCh37
+hco:12q21.31\/GRCh37
 	rdf:type	hco:12q21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7495,16 +7495,16 @@ hco:12q21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q21.31#GRCh38
+hco:12q21.31\/GRCh38
 	rdf:type	hco:12q21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7513,12 +7513,12 @@ hco:12q21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7526,7 +7526,7 @@ hco:12q21.32
 	rdfs:label	"12q21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q21.32#GRCh37
+hco:12q21.32\/GRCh37
 	rdf:type	hco:12q21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7535,16 +7535,16 @@ hco:12q21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q21.32#GRCh38
+hco:12q21.32\/GRCh38
 	rdf:type	hco:12q21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7553,12 +7553,12 @@ hco:12q21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7566,7 +7566,7 @@ hco:12q21.33
 	rdfs:label	"12q21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q21.33#GRCh37
+hco:12q21.33\/GRCh37
 	rdf:type	hco:12q21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7575,16 +7575,16 @@ hco:12q21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q21.33#GRCh38
+hco:12q21.33\/GRCh38
 	rdf:type	hco:12q21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -7593,12 +7593,12 @@ hco:12q21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7606,7 +7606,7 @@ hco:12q22
 	rdfs:label	"12q22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q22#GRCh37
+hco:12q22\/GRCh37
 	rdf:type	hco:12q22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7615,16 +7615,16 @@ hco:12q22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96200000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q22#GRCh38
+hco:12q22\/GRCh38
 	rdf:type	hco:12q22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7633,12 +7633,12 @@ hco:12q22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7646,7 +7646,7 @@ hco:12q23.1
 	rdfs:label	"12q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q23.1#GRCh37
+hco:12q23.1\/GRCh37
 	rdf:type	hco:12q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7655,16 +7655,16 @@ hco:12q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96200000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q23.1#GRCh38
+hco:12q23.1\/GRCh38
 	rdf:type	hco:12q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -7673,12 +7673,12 @@ hco:12q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95800000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7686,7 +7686,7 @@ hco:12q23.2
 	rdfs:label	"12q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q23.2#GRCh37
+hco:12q23.2\/GRCh37
 	rdf:type	hco:12q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7695,16 +7695,16 @@ hco:12q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101600000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q23.2#GRCh38
+hco:12q23.2\/GRCh38
 	rdf:type	hco:12q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7713,12 +7713,12 @@ hco:12q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7726,7 +7726,7 @@ hco:12q23.3
 	rdfs:label	"12q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q23.3#GRCh37
+hco:12q23.3\/GRCh37
 	rdf:type	hco:12q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7735,16 +7735,16 @@ hco:12q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q23.3#GRCh38
+hco:12q23.3\/GRCh38
 	rdf:type	hco:12q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7753,12 +7753,12 @@ hco:12q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103500000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7766,7 +7766,7 @@ hco:12q24.11
 	rdfs:label	"12q24.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.11#GRCh37
+hco:12q24.11\/GRCh37
 	rdf:type	hco:12q24.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7775,16 +7775,16 @@ hco:12q24.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109000000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.11#GRCh38
+hco:12q24.11\/GRCh38
 	rdf:type	hco:12q24.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7793,12 +7793,12 @@ hco:12q24.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108600000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7806,7 +7806,7 @@ hco:12q24.12
 	rdfs:label	"12q24.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.12#GRCh37
+hco:12q24.12\/GRCh37
 	rdf:type	hco:12q24.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7815,16 +7815,16 @@ hco:12q24.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.12#GRCh38
+hco:12q24.12\/GRCh38
 	rdf:type	hco:12q24.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -7833,12 +7833,12 @@ hco:12q24.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7846,7 +7846,7 @@ hco:12q24.13
 	rdfs:label	"12q24.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.13#GRCh37
+hco:12q24.13\/GRCh37
 	rdf:type	hco:12q24.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7855,16 +7855,16 @@ hco:12q24.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.13#GRCh38
+hco:12q24.13\/GRCh38
 	rdf:type	hco:12q24.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7873,12 +7873,12 @@ hco:12q24.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7886,7 +7886,7 @@ hco:12q24.21
 	rdfs:label	"12q24.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.21#GRCh37
+hco:12q24.21\/GRCh37
 	rdf:type	hco:12q24.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7895,16 +7895,16 @@ hco:12q24.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.21#GRCh38
+hco:12q24.21\/GRCh38
 	rdf:type	hco:12q24.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7913,12 +7913,12 @@ hco:12q24.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113900000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116400000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7926,7 +7926,7 @@ hco:12q24.22
 	rdfs:label	"12q24.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.22#GRCh37
+hco:12q24.22\/GRCh37
 	rdf:type	hco:12q24.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -7935,16 +7935,16 @@ hco:12q24.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116800000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.22#GRCh38
+hco:12q24.22\/GRCh38
 	rdf:type	hco:12q24.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -7953,12 +7953,12 @@ hco:12q24.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116400000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -7966,7 +7966,7 @@ hco:12q24.23
 	rdfs:label	"12q24.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.23#GRCh37
+hco:12q24.23\/GRCh37
 	rdf:type	hco:12q24.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7975,16 +7975,16 @@ hco:12q24.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.23#GRCh38
+hco:12q24.23\/GRCh38
 	rdf:type	hco:12q24.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -7993,12 +7993,12 @@ hco:12q24.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -8006,7 +8006,7 @@ hco:12q24.31
 	rdfs:label	"12q24.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.31#GRCh37
+hco:12q24.31\/GRCh37
 	rdf:type	hco:12q24.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8015,16 +8015,16 @@ hco:12q24.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120700000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125900000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.31#GRCh38
+hco:12q24.31\/GRCh38
 	rdf:type	hco:12q24.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8033,12 +8033,12 @@ hco:12q24.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120300000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125400000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -8046,7 +8046,7 @@ hco:12q24.32
 	rdfs:label	"12q24.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.32#GRCh37
+hco:12q24.32\/GRCh37
 	rdf:type	hco:12q24.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8055,16 +8055,16 @@ hco:12q24.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125900000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.32#GRCh38
+hco:12q24.32\/GRCh38
 	rdf:type	hco:12q24.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8073,12 +8073,12 @@ hco:12q24.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125400000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -8086,7 +8086,7 @@ hco:12q24.33
 	rdfs:label	"12q24.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:12q24.33#GRCh37
+hco:12q24.33\/GRCh37
 	rdf:type	hco:12q24.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8095,16 +8095,16 @@ hco:12q24.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129300000 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133851895 ;
-			faldo:reference	hco:12#GRCh37
+			faldo:reference	hco:12\/GRCh37
 		]
 	] .
 
-hco:12q24.33#GRCh38
+hco:12q24.33\/GRCh38
 	rdf:type	hco:12q24.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8113,12 +8113,12 @@ hco:12q24.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128700000 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133275309 ;
-			faldo:reference	hco:12#GRCh38
+			faldo:reference	hco:12\/GRCh38
 		]
 	] .
 
@@ -8126,7 +8126,7 @@ hco:13p13
 	rdfs:label	"13p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13p13#GRCh37
+hco:13p13\/GRCh37
 	rdf:type	hco:13p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -8135,16 +8135,16 @@ hco:13p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13p13#GRCh38
+hco:13p13\/GRCh38
 	rdf:type	hco:13p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -8153,12 +8153,12 @@ hco:13p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8166,7 +8166,7 @@ hco:13p12
 	rdfs:label	"13p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13p12#GRCh37
+hco:13p12\/GRCh37
 	rdf:type	hco:13p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Stalk ;
@@ -8175,16 +8175,16 @@ hco:13p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13p12#GRCh38
+hco:13p12\/GRCh38
 	rdf:type	hco:13p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Stalk ;
@@ -8193,12 +8193,12 @@ hco:13p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8206,7 +8206,7 @@ hco:13p11.2
 	rdfs:label	"13p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13p11.2#GRCh37
+hco:13p11.2\/GRCh37
 	rdf:type	hco:13p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -8215,16 +8215,16 @@ hco:13p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13p11.2#GRCh38
+hco:13p11.2\/GRCh38
 	rdf:type	hco:13p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -8233,12 +8233,12 @@ hco:13p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8246,7 +8246,7 @@ hco:13p11.1
 	rdfs:label	"13p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13p11.1#GRCh37
+hco:13p11.1\/GRCh37
 	rdf:type	hco:13p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -8255,16 +8255,16 @@ hco:13p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13p11.1#GRCh38
+hco:13p11.1\/GRCh38
 	rdf:type	hco:13p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -8273,12 +8273,12 @@ hco:13p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8286,7 +8286,7 @@ hco:13q11
 	rdfs:label	"13q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q11#GRCh37
+hco:13q11\/GRCh37
 	rdf:type	hco:13q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -8295,16 +8295,16 @@ hco:13q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q11#GRCh38
+hco:13q11\/GRCh38
 	rdf:type	hco:13q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -8313,12 +8313,12 @@ hco:13q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8326,7 +8326,7 @@ hco:13q12.11
 	rdfs:label	"13q12.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q12.11#GRCh37
+hco:13q12.11\/GRCh37
 	rdf:type	hco:13q12.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8335,16 +8335,16 @@ hco:13q12.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q12.11#GRCh38
+hco:13q12.11\/GRCh38
 	rdf:type	hco:13q12.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8353,12 +8353,12 @@ hco:13q12.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8366,7 +8366,7 @@ hco:13q12.12
 	rdfs:label	"13q12.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q12.12#GRCh37
+hco:13q12.12\/GRCh37
 	rdf:type	hco:13q12.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8375,16 +8375,16 @@ hco:13q12.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q12.12#GRCh38
+hco:13q12.12\/GRCh38
 	rdf:type	hco:13q12.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8393,12 +8393,12 @@ hco:13q12.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8406,7 +8406,7 @@ hco:13q12.13
 	rdfs:label	"13q12.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q12.13#GRCh37
+hco:13q12.13\/GRCh37
 	rdf:type	hco:13q12.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8415,16 +8415,16 @@ hco:13q12.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q12.13#GRCh38
+hco:13q12.13\/GRCh38
 	rdf:type	hco:13q12.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8433,12 +8433,12 @@ hco:13q12.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8446,7 +8446,7 @@ hco:13q12.2
 	rdfs:label	"13q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q12.2#GRCh37
+hco:13q12.2\/GRCh37
 	rdf:type	hco:13q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8455,16 +8455,16 @@ hco:13q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q12.2#GRCh38
+hco:13q12.2\/GRCh38
 	rdf:type	hco:13q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8473,12 +8473,12 @@ hco:13q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28300000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8486,7 +8486,7 @@ hco:13q12.3
 	rdfs:label	"13q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q12.3#GRCh37
+hco:13q12.3\/GRCh37
 	rdf:type	hco:13q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8495,16 +8495,16 @@ hco:13q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q12.3#GRCh38
+hco:13q12.3\/GRCh38
 	rdf:type	hco:13q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8513,12 +8513,12 @@ hco:13q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28300000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8526,7 +8526,7 @@ hco:13q13.1
 	rdfs:label	"13q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q13.1#GRCh37
+hco:13q13.1\/GRCh37
 	rdf:type	hco:13q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8535,16 +8535,16 @@ hco:13q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q13.1#GRCh38
+hco:13q13.1\/GRCh38
 	rdf:type	hco:13q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8553,12 +8553,12 @@ hco:13q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8566,7 +8566,7 @@ hco:13q13.2
 	rdfs:label	"13q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q13.2#GRCh37
+hco:13q13.2\/GRCh37
 	rdf:type	hco:13q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8575,16 +8575,16 @@ hco:13q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q13.2#GRCh38
+hco:13q13.2\/GRCh38
 	rdf:type	hco:13q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8593,12 +8593,12 @@ hco:13q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8606,7 +8606,7 @@ hco:13q13.3
 	rdfs:label	"13q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q13.3#GRCh37
+hco:13q13.3\/GRCh37
 	rdf:type	hco:13q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -8615,16 +8615,16 @@ hco:13q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q13.3#GRCh38
+hco:13q13.3\/GRCh38
 	rdf:type	hco:13q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -8633,12 +8633,12 @@ hco:13q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8646,7 +8646,7 @@ hco:13q14.11
 	rdfs:label	"13q14.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q14.11#GRCh37
+hco:13q14.11\/GRCh37
 	rdf:type	hco:13q14.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8655,16 +8655,16 @@ hco:13q14.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q14.11#GRCh38
+hco:13q14.11\/GRCh38
 	rdf:type	hco:13q14.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8673,12 +8673,12 @@ hco:13q14.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8686,7 +8686,7 @@ hco:13q14.12
 	rdfs:label	"13q14.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q14.12#GRCh37
+hco:13q14.12\/GRCh37
 	rdf:type	hco:13q14.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8695,16 +8695,16 @@ hco:13q14.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q14.12#GRCh38
+hco:13q14.12\/GRCh38
 	rdf:type	hco:13q14.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -8713,12 +8713,12 @@ hco:13q14.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8726,7 +8726,7 @@ hco:13q14.13
 	rdfs:label	"13q14.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q14.13#GRCh37
+hco:13q14.13\/GRCh37
 	rdf:type	hco:13q14.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8735,16 +8735,16 @@ hco:13q14.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q14.13#GRCh38
+hco:13q14.13\/GRCh38
 	rdf:type	hco:13q14.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8753,12 +8753,12 @@ hco:13q14.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8766,7 +8766,7 @@ hco:13q14.2
 	rdfs:label	"13q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q14.2#GRCh37
+hco:13q14.2\/GRCh37
 	rdf:type	hco:13q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8775,16 +8775,16 @@ hco:13q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q14.2#GRCh38
+hco:13q14.2\/GRCh38
 	rdf:type	hco:13q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -8793,12 +8793,12 @@ hco:13q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50300000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8806,7 +8806,7 @@ hco:13q14.3
 	rdfs:label	"13q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q14.3#GRCh37
+hco:13q14.3\/GRCh37
 	rdf:type	hco:13q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8815,16 +8815,16 @@ hco:13q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q14.3#GRCh38
+hco:13q14.3\/GRCh38
 	rdf:type	hco:13q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8833,12 +8833,12 @@ hco:13q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50300000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8846,7 +8846,7 @@ hco:13q21.1
 	rdfs:label	"13q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q21.1#GRCh37
+hco:13q21.1\/GRCh37
 	rdf:type	hco:13q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -8855,16 +8855,16 @@ hco:13q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59600000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q21.1#GRCh38
+hco:13q21.1\/GRCh38
 	rdf:type	hco:13q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -8873,12 +8873,12 @@ hco:13q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8886,7 +8886,7 @@ hco:13q21.2
 	rdfs:label	"13q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q21.2#GRCh37
+hco:13q21.2\/GRCh37
 	rdf:type	hco:13q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8895,16 +8895,16 @@ hco:13q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59600000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q21.2#GRCh38
+hco:13q21.2\/GRCh38
 	rdf:type	hco:13q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8913,12 +8913,12 @@ hco:13q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61800000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8926,7 +8926,7 @@ hco:13q21.31
 	rdfs:label	"13q21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q21.31#GRCh37
+hco:13q21.31\/GRCh37
 	rdf:type	hco:13q21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -8935,16 +8935,16 @@ hco:13q21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q21.31#GRCh38
+hco:13q21.31\/GRCh38
 	rdf:type	hco:13q21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -8953,12 +8953,12 @@ hco:13q21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61800000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -8966,7 +8966,7 @@ hco:13q21.32
 	rdfs:label	"13q21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q21.32#GRCh37
+hco:13q21.32\/GRCh37
 	rdf:type	hco:13q21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -8975,16 +8975,16 @@ hco:13q21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68600000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q21.32#GRCh38
+hco:13q21.32\/GRCh38
 	rdf:type	hco:13q21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -8993,12 +8993,12 @@ hco:13q21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9006,7 +9006,7 @@ hco:13q21.33
 	rdfs:label	"13q21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q21.33#GRCh37
+hco:13q21.33\/GRCh37
 	rdf:type	hco:13q21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9015,16 +9015,16 @@ hco:13q21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68600000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q21.33#GRCh38
+hco:13q21.33\/GRCh38
 	rdf:type	hco:13q21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9033,12 +9033,12 @@ hco:13q21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72800000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9046,7 +9046,7 @@ hco:13q22.1
 	rdfs:label	"13q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q22.1#GRCh37
+hco:13q22.1\/GRCh37
 	rdf:type	hco:13q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9055,16 +9055,16 @@ hco:13q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75400000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q22.1#GRCh38
+hco:13q22.1\/GRCh38
 	rdf:type	hco:13q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9073,12 +9073,12 @@ hco:13q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72800000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9086,7 +9086,7 @@ hco:13q22.2
 	rdfs:label	"13q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q22.2#GRCh37
+hco:13q22.2\/GRCh37
 	rdf:type	hco:13q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -9095,16 +9095,16 @@ hco:13q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75400000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q22.2#GRCh38
+hco:13q22.2\/GRCh38
 	rdf:type	hco:13q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -9113,12 +9113,12 @@ hco:13q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9126,7 +9126,7 @@ hco:13q22.3
 	rdfs:label	"13q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q22.3#GRCh37
+hco:13q22.3\/GRCh37
 	rdf:type	hco:13q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9135,16 +9135,16 @@ hco:13q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q22.3#GRCh38
+hco:13q22.3\/GRCh38
 	rdf:type	hco:13q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9153,12 +9153,12 @@ hco:13q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9166,7 +9166,7 @@ hco:13q31.1
 	rdfs:label	"13q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q31.1#GRCh37
+hco:13q31.1\/GRCh37
 	rdf:type	hco:13q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9175,16 +9175,16 @@ hco:13q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q31.1#GRCh38
+hco:13q31.1\/GRCh38
 	rdf:type	hco:13q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9193,12 +9193,12 @@ hco:13q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9206,7 +9206,7 @@ hco:13q31.2
 	rdfs:label	"13q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q31.2#GRCh37
+hco:13q31.2\/GRCh37
 	rdf:type	hco:13q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9215,16 +9215,16 @@ hco:13q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q31.2#GRCh38
+hco:13q31.2\/GRCh38
 	rdf:type	hco:13q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9233,12 +9233,12 @@ hco:13q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9246,7 +9246,7 @@ hco:13q31.3
 	rdfs:label	"13q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q31.3#GRCh37
+hco:13q31.3\/GRCh37
 	rdf:type	hco:13q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9255,16 +9255,16 @@ hco:13q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q31.3#GRCh38
+hco:13q31.3\/GRCh38
 	rdf:type	hco:13q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9273,12 +9273,12 @@ hco:13q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9286,7 +9286,7 @@ hco:13q32.1
 	rdfs:label	"13q32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q32.1#GRCh37
+hco:13q32.1\/GRCh37
 	rdf:type	hco:13q32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9295,16 +9295,16 @@ hco:13q32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q32.1#GRCh38
+hco:13q32.1\/GRCh38
 	rdf:type	hco:13q32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9313,12 +9313,12 @@ hco:13q32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9326,7 +9326,7 @@ hco:13q32.2
 	rdfs:label	"13q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q32.2#GRCh37
+hco:13q32.2\/GRCh37
 	rdf:type	hco:13q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -9335,16 +9335,16 @@ hco:13q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98200000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q32.2#GRCh38
+hco:13q32.2\/GRCh38
 	rdf:type	hco:13q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -9353,12 +9353,12 @@ hco:13q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97500000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9366,7 +9366,7 @@ hco:13q32.3
 	rdfs:label	"13q32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q32.3#GRCh37
+hco:13q32.3\/GRCh37
 	rdf:type	hco:13q32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9375,16 +9375,16 @@ hco:13q32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q32.3#GRCh38
+hco:13q32.3\/GRCh38
 	rdf:type	hco:13q32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9393,12 +9393,12 @@ hco:13q32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98700000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9406,7 +9406,7 @@ hco:13q33.1
 	rdfs:label	"13q33.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q33.1#GRCh37
+hco:13q33.1\/GRCh37
 	rdf:type	hco:13q33.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9415,16 +9415,16 @@ hco:13q33.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101700000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q33.1#GRCh38
+hco:13q33.1\/GRCh38
 	rdf:type	hco:13q33.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9433,12 +9433,12 @@ hco:13q33.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101100000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9446,7 +9446,7 @@ hco:13q33.2
 	rdfs:label	"13q33.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q33.2#GRCh37
+hco:13q33.2\/GRCh37
 	rdf:type	hco:13q33.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9455,16 +9455,16 @@ hco:13q33.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104800000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q33.2#GRCh38
+hco:13q33.2\/GRCh38
 	rdf:type	hco:13q33.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9473,12 +9473,12 @@ hco:13q33.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104200000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9486,7 +9486,7 @@ hco:13q33.3
 	rdfs:label	"13q33.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q33.3#GRCh37
+hco:13q33.3\/GRCh37
 	rdf:type	hco:13q33.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9495,16 +9495,16 @@ hco:13q33.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107000000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q33.3#GRCh38
+hco:13q33.3\/GRCh38
 	rdf:type	hco:13q33.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9513,12 +9513,12 @@ hco:13q33.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106400000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9526,7 +9526,7 @@ hco:13q34
 	rdfs:label	"13q34" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:13q34#GRCh37
+hco:13q34\/GRCh37
 	rdf:type	hco:13q34 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9535,16 +9535,16 @@ hco:13q34#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110300000 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115169878 ;
-			faldo:reference	hco:13#GRCh37
+			faldo:reference	hco:13\/GRCh37
 		]
 	] .
 
-hco:13q34#GRCh38
+hco:13q34\/GRCh38
 	rdf:type	hco:13q34 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9553,12 +9553,12 @@ hco:13q34#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109600000 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114364328 ;
-			faldo:reference	hco:13#GRCh38
+			faldo:reference	hco:13\/GRCh38
 		]
 	] .
 
@@ -9566,7 +9566,7 @@ hco:14p13
 	rdfs:label	"14p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14p13#GRCh37
+hco:14p13\/GRCh37
 	rdf:type	hco:14p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -9575,16 +9575,16 @@ hco:14p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3700000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14p13#GRCh38
+hco:14p13\/GRCh38
 	rdf:type	hco:14p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -9593,12 +9593,12 @@ hco:14p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9606,7 +9606,7 @@ hco:14p12
 	rdfs:label	"14p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14p12#GRCh37
+hco:14p12\/GRCh37
 	rdf:type	hco:14p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Stalk ;
@@ -9615,16 +9615,16 @@ hco:14p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3700000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14p12#GRCh38
+hco:14p12\/GRCh38
 	rdf:type	hco:14p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Stalk ;
@@ -9633,12 +9633,12 @@ hco:14p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9646,7 +9646,7 @@ hco:14p11.2
 	rdfs:label	"14p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14p11.2#GRCh37
+hco:14p11.2\/GRCh37
 	rdf:type	hco:14p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -9655,16 +9655,16 @@ hco:14p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14p11.2#GRCh38
+hco:14p11.2\/GRCh38
 	rdf:type	hco:14p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -9673,12 +9673,12 @@ hco:14p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9686,7 +9686,7 @@ hco:14p11.1
 	rdfs:label	"14p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14p11.1#GRCh37
+hco:14p11.1\/GRCh37
 	rdf:type	hco:14p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -9695,16 +9695,16 @@ hco:14p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14p11.1#GRCh38
+hco:14p11.1\/GRCh38
 	rdf:type	hco:14p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -9713,12 +9713,12 @@ hco:14p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9726,7 +9726,7 @@ hco:14q11.1
 	rdfs:label	"14q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q11.1#GRCh37
+hco:14q11.1\/GRCh37
 	rdf:type	hco:14q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -9735,16 +9735,16 @@ hco:14q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q11.1#GRCh38
+hco:14q11.1\/GRCh38
 	rdf:type	hco:14q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -9753,12 +9753,12 @@ hco:14q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9766,7 +9766,7 @@ hco:14q11.2
 	rdfs:label	"14q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q11.2#GRCh37
+hco:14q11.2\/GRCh37
 	rdf:type	hco:14q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9775,16 +9775,16 @@ hco:14q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q11.2#GRCh38
+hco:14q11.2\/GRCh38
 	rdf:type	hco:14q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9793,12 +9793,12 @@ hco:14q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9806,7 +9806,7 @@ hco:14q12
 	rdfs:label	"14q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q12#GRCh37
+hco:14q12\/GRCh37
 	rdf:type	hco:14q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9815,16 +9815,16 @@ hco:14q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q12#GRCh38
+hco:14q12\/GRCh38
 	rdf:type	hco:14q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9833,12 +9833,12 @@ hco:14q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32900000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9846,7 +9846,7 @@ hco:14q13.1
 	rdfs:label	"14q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q13.1#GRCh37
+hco:14q13.1\/GRCh37
 	rdf:type	hco:14q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9855,16 +9855,16 @@ hco:14q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q13.1#GRCh38
+hco:14q13.1\/GRCh38
 	rdf:type	hco:14q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9873,12 +9873,12 @@ hco:14q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32900000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9886,7 +9886,7 @@ hco:14q13.2
 	rdfs:label	"14q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q13.2#GRCh37
+hco:14q13.2\/GRCh37
 	rdf:type	hco:14q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -9895,16 +9895,16 @@ hco:14q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q13.2#GRCh38
+hco:14q13.2\/GRCh38
 	rdf:type	hco:14q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -9913,12 +9913,12 @@ hco:14q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9926,7 +9926,7 @@ hco:14q13.3
 	rdfs:label	"14q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q13.3#GRCh37
+hco:14q13.3\/GRCh37
 	rdf:type	hco:14q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -9935,16 +9935,16 @@ hco:14q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q13.3#GRCh38
+hco:14q13.3\/GRCh38
 	rdf:type	hco:14q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -9953,12 +9953,12 @@ hco:14q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -9966,7 +9966,7 @@ hco:14q21.1
 	rdfs:label	"14q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q21.1#GRCh37
+hco:14q21.1\/GRCh37
 	rdf:type	hco:14q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9975,16 +9975,16 @@ hco:14q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q21.1#GRCh38
+hco:14q21.1\/GRCh38
 	rdf:type	hco:14q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -9993,12 +9993,12 @@ hco:14q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10006,7 +10006,7 @@ hco:14q21.2
 	rdfs:label	"14q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q21.2#GRCh37
+hco:14q21.2\/GRCh37
 	rdf:type	hco:14q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10015,16 +10015,16 @@ hco:14q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q21.2#GRCh38
+hco:14q21.2\/GRCh38
 	rdf:type	hco:14q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10033,12 +10033,12 @@ hco:14q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46700000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10046,7 +10046,7 @@ hco:14q21.3
 	rdfs:label	"14q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q21.3#GRCh37
+hco:14q21.3\/GRCh37
 	rdf:type	hco:14q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10055,16 +10055,16 @@ hco:14q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q21.3#GRCh38
+hco:14q21.3\/GRCh38
 	rdf:type	hco:14q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10073,12 +10073,12 @@ hco:14q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46700000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10086,7 +10086,7 @@ hco:14q22.1
 	rdfs:label	"14q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q22.1#GRCh37
+hco:14q22.1\/GRCh37
 	rdf:type	hco:14q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10095,16 +10095,16 @@ hco:14q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q22.1#GRCh38
+hco:14q22.1\/GRCh38
 	rdf:type	hco:14q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10113,12 +10113,12 @@ hco:14q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10126,7 +10126,7 @@ hco:14q22.2
 	rdfs:label	"14q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q22.2#GRCh37
+hco:14q22.2\/GRCh37
 	rdf:type	hco:14q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -10135,16 +10135,16 @@ hco:14q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55500000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q22.2#GRCh38
+hco:14q22.2\/GRCh38
 	rdf:type	hco:14q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -10153,12 +10153,12 @@ hco:14q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10166,7 +10166,7 @@ hco:14q22.3
 	rdfs:label	"14q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q22.3#GRCh37
+hco:14q22.3\/GRCh37
 	rdf:type	hco:14q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10175,16 +10175,16 @@ hco:14q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55500000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q22.3#GRCh38
+hco:14q22.3\/GRCh38
 	rdf:type	hco:14q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10193,12 +10193,12 @@ hco:14q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10206,7 +10206,7 @@ hco:14q23.1
 	rdfs:label	"14q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q23.1#GRCh37
+hco:14q23.1\/GRCh37
 	rdf:type	hco:14q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -10215,16 +10215,16 @@ hco:14q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q23.1#GRCh38
+hco:14q23.1\/GRCh38
 	rdf:type	hco:14q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -10233,12 +10233,12 @@ hco:14q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10246,7 +10246,7 @@ hco:14q23.2
 	rdfs:label	"14q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q23.2#GRCh37
+hco:14q23.2\/GRCh37
 	rdf:type	hco:14q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10255,16 +10255,16 @@ hco:14q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62100000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q23.2#GRCh38
+hco:14q23.2\/GRCh38
 	rdf:type	hco:14q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10273,12 +10273,12 @@ hco:14q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10286,7 +10286,7 @@ hco:14q23.3
 	rdfs:label	"14q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q23.3#GRCh37
+hco:14q23.3\/GRCh37
 	rdf:type	hco:14q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10295,16 +10295,16 @@ hco:14q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q23.3#GRCh38
+hco:14q23.3\/GRCh38
 	rdf:type	hco:14q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10313,12 +10313,12 @@ hco:14q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10326,7 +10326,7 @@ hco:14q24.1
 	rdfs:label	"14q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q24.1#GRCh37
+hco:14q24.1\/GRCh37
 	rdf:type	hco:14q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10335,16 +10335,16 @@ hco:14q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q24.1#GRCh38
+hco:14q24.1\/GRCh38
 	rdf:type	hco:14q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10353,12 +10353,12 @@ hco:14q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10366,7 +10366,7 @@ hco:14q24.2
 	rdfs:label	"14q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q24.2#GRCh37
+hco:14q24.2\/GRCh37
 	rdf:type	hco:14q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10375,16 +10375,16 @@ hco:14q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q24.2#GRCh38
+hco:14q24.2\/GRCh38
 	rdf:type	hco:14q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10393,12 +10393,12 @@ hco:14q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10406,7 +10406,7 @@ hco:14q24.3
 	rdfs:label	"14q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q24.3#GRCh37
+hco:14q24.3\/GRCh37
 	rdf:type	hco:14q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10415,16 +10415,16 @@ hco:14q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q24.3#GRCh38
+hco:14q24.3\/GRCh38
 	rdf:type	hco:14q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10433,12 +10433,12 @@ hco:14q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10446,7 +10446,7 @@ hco:14q31.1
 	rdfs:label	"14q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q31.1#GRCh37
+hco:14q31.1\/GRCh37
 	rdf:type	hco:14q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10455,16 +10455,16 @@ hco:14q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q31.1#GRCh38
+hco:14q31.1\/GRCh38
 	rdf:type	hco:14q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10473,12 +10473,12 @@ hco:14q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10486,7 +10486,7 @@ hco:14q31.2
 	rdfs:label	"14q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q31.2#GRCh37
+hco:14q31.2\/GRCh37
 	rdf:type	hco:14q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10495,16 +10495,16 @@ hco:14q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83600000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q31.2#GRCh38
+hco:14q31.2\/GRCh38
 	rdf:type	hco:14q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10513,12 +10513,12 @@ hco:14q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83100000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10526,7 +10526,7 @@ hco:14q31.3
 	rdfs:label	"14q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q31.3#GRCh37
+hco:14q31.3\/GRCh37
 	rdf:type	hco:14q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10535,16 +10535,16 @@ hco:14q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q31.3#GRCh38
+hco:14q31.3\/GRCh38
 	rdf:type	hco:14q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -10553,12 +10553,12 @@ hco:14q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10566,7 +10566,7 @@ hco:14q32.11
 	rdfs:label	"14q32.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.11#GRCh37
+hco:14q32.11\/GRCh37
 	rdf:type	hco:14q32.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10575,16 +10575,16 @@ hco:14q32.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89800000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.11#GRCh38
+hco:14q32.11\/GRCh38
 	rdf:type	hco:14q32.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10593,12 +10593,12 @@ hco:14q32.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89300000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10606,7 +10606,7 @@ hco:14q32.12
 	rdfs:label	"14q32.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.12#GRCh37
+hco:14q32.12\/GRCh37
 	rdf:type	hco:14q32.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -10615,16 +10615,16 @@ hco:14q32.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91900000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94700000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.12#GRCh38
+hco:14q32.12\/GRCh38
 	rdf:type	hco:14q32.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -10633,12 +10633,12 @@ hco:14q32.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91400000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10646,7 +10646,7 @@ hco:14q32.13
 	rdfs:label	"14q32.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.13#GRCh37
+hco:14q32.13\/GRCh37
 	rdf:type	hco:14q32.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10655,16 +10655,16 @@ hco:14q32.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94700000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.13#GRCh38
+hco:14q32.13\/GRCh38
 	rdf:type	hco:14q32.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10673,12 +10673,12 @@ hco:14q32.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94200000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10686,7 +10686,7 @@ hco:14q32.2
 	rdfs:label	"14q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.2#GRCh37
+hco:14q32.2\/GRCh37
 	rdf:type	hco:14q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10695,16 +10695,16 @@ hco:14q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96300000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101400000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.2#GRCh38
+hco:14q32.2\/GRCh38
 	rdf:type	hco:14q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10713,12 +10713,12 @@ hco:14q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95800000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100900000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10726,7 +10726,7 @@ hco:14q32.31
 	rdfs:label	"14q32.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.31#GRCh37
+hco:14q32.31\/GRCh37
 	rdf:type	hco:14q32.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10735,16 +10735,16 @@ hco:14q32.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101400000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.31#GRCh38
+hco:14q32.31\/GRCh38
 	rdf:type	hco:14q32.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10753,12 +10753,12 @@ hco:14q32.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100900000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102700000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10766,7 +10766,7 @@ hco:14q32.32
 	rdfs:label	"14q32.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.32#GRCh37
+hco:14q32.32\/GRCh37
 	rdf:type	hco:14q32.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10775,16 +10775,16 @@ hco:14q32.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103200000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104000000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.32#GRCh38
+hco:14q32.32\/GRCh38
 	rdf:type	hco:14q32.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -10793,12 +10793,12 @@ hco:14q32.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102700000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103500000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10806,7 +10806,7 @@ hco:14q32.33
 	rdfs:label	"14q32.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:14q32.33#GRCh37
+hco:14q32.33\/GRCh37
 	rdf:type	hco:14q32.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -10815,16 +10815,16 @@ hco:14q32.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104000000 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107349540 ;
-			faldo:reference	hco:14#GRCh37
+			faldo:reference	hco:14\/GRCh37
 		]
 	] .
 
-hco:14q32.33#GRCh38
+hco:14q32.33\/GRCh38
 	rdf:type	hco:14q32.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -10833,12 +10833,12 @@ hco:14q32.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103500000 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107043718 ;
-			faldo:reference	hco:14#GRCh38
+			faldo:reference	hco:14\/GRCh38
 		]
 	] .
 
@@ -10846,7 +10846,7 @@ hco:15p13
 	rdfs:label	"15p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15p13#GRCh37
+hco:15p13\/GRCh37
 	rdf:type	hco:15p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -10855,16 +10855,16 @@ hco:15p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3900000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15p13#GRCh38
+hco:15p13\/GRCh38
 	rdf:type	hco:15p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -10873,12 +10873,12 @@ hco:15p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -10886,7 +10886,7 @@ hco:15p12
 	rdfs:label	"15p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15p12#GRCh37
+hco:15p12\/GRCh37
 	rdf:type	hco:15p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Stalk ;
@@ -10895,16 +10895,16 @@ hco:15p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3900000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15p12#GRCh38
+hco:15p12\/GRCh38
 	rdf:type	hco:15p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Stalk ;
@@ -10913,12 +10913,12 @@ hco:15p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9700000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -10926,7 +10926,7 @@ hco:15p11.2
 	rdfs:label	"15p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15p11.2#GRCh37
+hco:15p11.2\/GRCh37
 	rdf:type	hco:15p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -10935,16 +10935,16 @@ hco:15p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15p11.2#GRCh38
+hco:15p11.2\/GRCh38
 	rdf:type	hco:15p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -10953,12 +10953,12 @@ hco:15p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9700000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -10966,7 +10966,7 @@ hco:15p11.1
 	rdfs:label	"15p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15p11.1#GRCh37
+hco:15p11.1\/GRCh37
 	rdf:type	hco:15p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -10975,16 +10975,16 @@ hco:15p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15p11.1#GRCh38
+hco:15p11.1\/GRCh38
 	rdf:type	hco:15p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -10993,12 +10993,12 @@ hco:15p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11006,7 +11006,7 @@ hco:15q11.1
 	rdfs:label	"15q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q11.1#GRCh37
+hco:15q11.1\/GRCh37
 	rdf:type	hco:15q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -11015,16 +11015,16 @@ hco:15q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q11.1#GRCh38
+hco:15q11.1\/GRCh38
 	rdf:type	hco:15q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -11033,12 +11033,12 @@ hco:15q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11046,7 +11046,7 @@ hco:15q11.2
 	rdfs:label	"15q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q11.2#GRCh37
+hco:15q11.2\/GRCh37
 	rdf:type	hco:15q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11055,16 +11055,16 @@ hco:15q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q11.2#GRCh38
+hco:15q11.2\/GRCh38
 	rdf:type	hco:15q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11073,12 +11073,12 @@ hco:15q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11086,7 +11086,7 @@ hco:15q12
 	rdfs:label	"15q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q12#GRCh37
+hco:15q12\/GRCh37
 	rdf:type	hco:15q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11095,16 +11095,16 @@ hco:15q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q12#GRCh38
+hco:15q12\/GRCh38
 	rdf:type	hco:15q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11113,12 +11113,12 @@ hco:15q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11126,7 +11126,7 @@ hco:15q13.1
 	rdfs:label	"15q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q13.1#GRCh37
+hco:15q13.1\/GRCh37
 	rdf:type	hco:15q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11135,16 +11135,16 @@ hco:15q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q13.1#GRCh38
+hco:15q13.1\/GRCh38
 	rdf:type	hco:15q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11153,12 +11153,12 @@ hco:15q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11166,7 +11166,7 @@ hco:15q13.2
 	rdfs:label	"15q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q13.2#GRCh37
+hco:15q13.2\/GRCh37
 	rdf:type	hco:15q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11175,16 +11175,16 @@ hco:15q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q13.2#GRCh38
+hco:15q13.2\/GRCh38
 	rdf:type	hco:15q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11193,12 +11193,12 @@ hco:15q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11206,7 +11206,7 @@ hco:15q13.3
 	rdfs:label	"15q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q13.3#GRCh37
+hco:15q13.3\/GRCh37
 	rdf:type	hco:15q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11215,16 +11215,16 @@ hco:15q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q13.3#GRCh38
+hco:15q13.3\/GRCh38
 	rdf:type	hco:15q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11233,12 +11233,12 @@ hco:15q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11246,7 +11246,7 @@ hco:15q14
 	rdfs:label	"15q14" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q14#GRCh37
+hco:15q14\/GRCh37
 	rdf:type	hco:15q14 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11255,16 +11255,16 @@ hco:15q14#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q14#GRCh38
+hco:15q14\/GRCh38
 	rdf:type	hco:15q14 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11273,12 +11273,12 @@ hco:15q14#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11286,7 +11286,7 @@ hco:15q15.1
 	rdfs:label	"15q15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q15.1#GRCh37
+hco:15q15.1\/GRCh37
 	rdf:type	hco:15q15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11295,16 +11295,16 @@ hco:15q15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q15.1#GRCh38
+hco:15q15.1\/GRCh38
 	rdf:type	hco:15q15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11313,12 +11313,12 @@ hco:15q15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11326,7 +11326,7 @@ hco:15q15.2
 	rdfs:label	"15q15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q15.2#GRCh37
+hco:15q15.2\/GRCh37
 	rdf:type	hco:15q15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11335,16 +11335,16 @@ hco:15q15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q15.2#GRCh38
+hco:15q15.2\/GRCh38
 	rdf:type	hco:15q15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11353,12 +11353,12 @@ hco:15q15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11366,7 +11366,7 @@ hco:15q15.3
 	rdfs:label	"15q15.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q15.3#GRCh37
+hco:15q15.3\/GRCh37
 	rdf:type	hco:15q15.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11375,16 +11375,16 @@ hco:15q15.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q15.3#GRCh38
+hco:15q15.3\/GRCh38
 	rdf:type	hco:15q15.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11393,12 +11393,12 @@ hco:15q15.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11406,7 +11406,7 @@ hco:15q21.1
 	rdfs:label	"15q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q21.1#GRCh37
+hco:15q21.1\/GRCh37
 	rdf:type	hco:15q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11415,16 +11415,16 @@ hco:15q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44800000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q21.1#GRCh38
+hco:15q21.1\/GRCh38
 	rdf:type	hco:15q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11433,12 +11433,12 @@ hco:15q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11446,7 +11446,7 @@ hco:15q21.2
 	rdfs:label	"15q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q21.2#GRCh37
+hco:15q21.2\/GRCh37
 	rdf:type	hco:15q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11455,16 +11455,16 @@ hco:15q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q21.2#GRCh38
+hco:15q21.2\/GRCh38
 	rdf:type	hco:15q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11473,12 +11473,12 @@ hco:15q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11486,7 +11486,7 @@ hco:15q21.3
 	rdfs:label	"15q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q21.3#GRCh37
+hco:15q21.3\/GRCh37
 	rdf:type	hco:15q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11495,16 +11495,16 @@ hco:15q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q21.3#GRCh38
+hco:15q21.3\/GRCh38
 	rdf:type	hco:15q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -11513,12 +11513,12 @@ hco:15q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11526,7 +11526,7 @@ hco:15q22.1
 	rdfs:label	"15q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q22.1#GRCh37
+hco:15q22.1\/GRCh37
 	rdf:type	hco:15q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11535,16 +11535,16 @@ hco:15q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q22.1#GRCh38
+hco:15q22.1\/GRCh38
 	rdf:type	hco:15q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11553,12 +11553,12 @@ hco:15q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11566,7 +11566,7 @@ hco:15q22.2
 	rdfs:label	"15q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q22.2#GRCh37
+hco:15q22.2\/GRCh37
 	rdf:type	hco:15q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11575,16 +11575,16 @@ hco:15q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q22.2#GRCh38
+hco:15q22.2\/GRCh38
 	rdf:type	hco:15q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11593,12 +11593,12 @@ hco:15q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11606,7 +11606,7 @@ hco:15q22.31
 	rdfs:label	"15q22.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q22.31#GRCh37
+hco:15q22.31\/GRCh37
 	rdf:type	hco:15q22.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11615,16 +11615,16 @@ hco:15q22.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q22.31#GRCh38
+hco:15q22.31\/GRCh38
 	rdf:type	hco:15q22.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11633,12 +11633,12 @@ hco:15q22.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11646,7 +11646,7 @@ hco:15q22.32
 	rdfs:label	"15q22.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q22.32#GRCh37
+hco:15q22.32\/GRCh37
 	rdf:type	hco:15q22.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11655,16 +11655,16 @@ hco:15q22.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q22.32#GRCh38
+hco:15q22.32\/GRCh38
 	rdf:type	hco:15q22.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11673,12 +11673,12 @@ hco:15q22.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11686,7 +11686,7 @@ hco:15q22.33
 	rdfs:label	"15q22.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q22.33#GRCh37
+hco:15q22.33\/GRCh37
 	rdf:type	hco:15q22.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11695,16 +11695,16 @@ hco:15q22.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q22.33#GRCh38
+hco:15q22.33\/GRCh38
 	rdf:type	hco:15q22.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11713,12 +11713,12 @@ hco:15q22.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11726,7 +11726,7 @@ hco:15q23
 	rdfs:label	"15q23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q23#GRCh37
+hco:15q23\/GRCh37
 	rdf:type	hco:15q23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11735,16 +11735,16 @@ hco:15q23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q23#GRCh38
+hco:15q23\/GRCh38
 	rdf:type	hco:15q23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11753,12 +11753,12 @@ hco:15q23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67200000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11766,7 +11766,7 @@ hco:15q24.1
 	rdfs:label	"15q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q24.1#GRCh37
+hco:15q24.1\/GRCh37
 	rdf:type	hco:15q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11775,16 +11775,16 @@ hco:15q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q24.1#GRCh38
+hco:15q24.1\/GRCh38
 	rdf:type	hco:15q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11793,12 +11793,12 @@ hco:15q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11806,7 +11806,7 @@ hco:15q24.2
 	rdfs:label	"15q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q24.2#GRCh37
+hco:15q24.2\/GRCh37
 	rdf:type	hco:15q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11815,16 +11815,16 @@ hco:15q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q24.2#GRCh38
+hco:15q24.2\/GRCh38
 	rdf:type	hco:15q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -11833,12 +11833,12 @@ hco:15q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74900000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76300000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11846,7 +11846,7 @@ hco:15q24.3
 	rdfs:label	"15q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q24.3#GRCh37
+hco:15q24.3\/GRCh37
 	rdf:type	hco:15q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11855,16 +11855,16 @@ hco:15q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76600000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q24.3#GRCh38
+hco:15q24.3\/GRCh38
 	rdf:type	hco:15q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11873,12 +11873,12 @@ hco:15q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76300000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11886,7 +11886,7 @@ hco:15q25.1
 	rdfs:label	"15q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q25.1#GRCh37
+hco:15q25.1\/GRCh37
 	rdf:type	hco:15q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11895,16 +11895,16 @@ hco:15q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q25.1#GRCh38
+hco:15q25.1\/GRCh38
 	rdf:type	hco:15q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11913,12 +11913,12 @@ hco:15q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11926,7 +11926,7 @@ hco:15q25.2
 	rdfs:label	"15q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q25.2#GRCh37
+hco:15q25.2\/GRCh37
 	rdf:type	hco:15q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -11935,16 +11935,16 @@ hco:15q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81700000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q25.2#GRCh38
+hco:15q25.2\/GRCh38
 	rdf:type	hco:15q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -11953,12 +11953,12 @@ hco:15q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81400000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84700000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -11966,7 +11966,7 @@ hco:15q25.3
 	rdfs:label	"15q25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q25.3#GRCh37
+hco:15q25.3\/GRCh37
 	rdf:type	hco:15q25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11975,16 +11975,16 @@ hco:15q25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85200000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q25.3#GRCh38
+hco:15q25.3\/GRCh38
 	rdf:type	hco:15q25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -11993,12 +11993,12 @@ hco:15q25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84700000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -12006,7 +12006,7 @@ hco:15q26.1
 	rdfs:label	"15q26.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q26.1#GRCh37
+hco:15q26.1\/GRCh37
 	rdf:type	hco:15q26.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12015,16 +12015,16 @@ hco:15q26.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89100000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q26.1#GRCh38
+hco:15q26.1\/GRCh38
 	rdf:type	hco:15q26.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12033,12 +12033,12 @@ hco:15q26.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88500000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -12046,7 +12046,7 @@ hco:15q26.2
 	rdfs:label	"15q26.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q26.2#GRCh37
+hco:15q26.2\/GRCh37
 	rdf:type	hco:15q26.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12055,16 +12055,16 @@ hco:15q26.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q26.2#GRCh38
+hco:15q26.2\/GRCh38
 	rdf:type	hco:15q26.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12073,12 +12073,12 @@ hco:15q26.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93800000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -12086,7 +12086,7 @@ hco:15q26.3
 	rdfs:label	"15q26.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:15q26.3#GRCh37
+hco:15q26.3\/GRCh37
 	rdf:type	hco:15q26.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12095,16 +12095,16 @@ hco:15q26.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98500000 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102531392 ;
-			faldo:reference	hco:15#GRCh37
+			faldo:reference	hco:15\/GRCh37
 		]
 	] .
 
-hco:15q26.3#GRCh38
+hco:15q26.3\/GRCh38
 	rdf:type	hco:15q26.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12113,12 +12113,12 @@ hco:15q26.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98000000 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101991189 ;
-			faldo:reference	hco:15#GRCh38
+			faldo:reference	hco:15\/GRCh38
 		]
 	] .
 
@@ -12126,7 +12126,7 @@ hco:16p13.3
 	rdfs:label	"16p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p13.3#GRCh37
+hco:16p13.3\/GRCh37
 	rdf:type	hco:16p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12135,16 +12135,16 @@ hco:16p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7900000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p13.3#GRCh38
+hco:16p13.3\/GRCh38
 	rdf:type	hco:16p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12153,12 +12153,12 @@ hco:16p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12166,7 +12166,7 @@ hco:16p13.2
 	rdfs:label	"16p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p13.2#GRCh37
+hco:16p13.2\/GRCh37
 	rdf:type	hco:16p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12175,16 +12175,16 @@ hco:16p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7900000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10500000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p13.2#GRCh38
+hco:16p13.2\/GRCh38
 	rdf:type	hco:16p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12193,12 +12193,12 @@ hco:16p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10400000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12206,7 +12206,7 @@ hco:16p13.13
 	rdfs:label	"16p13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p13.13#GRCh37
+hco:16p13.13\/GRCh37
 	rdf:type	hco:16p13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12215,16 +12215,16 @@ hco:16p13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10500000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p13.13#GRCh38
+hco:16p13.13\/GRCh38
 	rdf:type	hco:16p13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12233,12 +12233,12 @@ hco:16p13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10400000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12246,7 +12246,7 @@ hco:16p13.12
 	rdfs:label	"16p13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p13.12#GRCh37
+hco:16p13.12\/GRCh37
 	rdf:type	hco:16p13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12255,16 +12255,16 @@ hco:16p13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p13.12#GRCh38
+hco:16p13.12\/GRCh38
 	rdf:type	hco:16p13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12273,12 +12273,12 @@ hco:16p13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12286,7 +12286,7 @@ hco:16p13.11
 	rdfs:label	"16p13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p13.11#GRCh37
+hco:16p13.11\/GRCh37
 	rdf:type	hco:16p13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12295,16 +12295,16 @@ hco:16p13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p13.11#GRCh38
+hco:16p13.11\/GRCh38
 	rdf:type	hco:16p13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12313,12 +12313,12 @@ hco:16p13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12326,7 +12326,7 @@ hco:16p12.3
 	rdfs:label	"16p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p12.3#GRCh37
+hco:16p12.3\/GRCh37
 	rdf:type	hco:16p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12335,16 +12335,16 @@ hco:16p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p12.3#GRCh38
+hco:16p12.3\/GRCh38
 	rdf:type	hco:16p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12353,12 +12353,12 @@ hco:16p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12366,7 +12366,7 @@ hco:16p12.2
 	rdfs:label	"16p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p12.2#GRCh37
+hco:16p12.2\/GRCh37
 	rdf:type	hco:16p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12375,16 +12375,16 @@ hco:16p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p12.2#GRCh38
+hco:16p12.2\/GRCh38
 	rdf:type	hco:16p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12393,12 +12393,12 @@ hco:16p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12406,7 +12406,7 @@ hco:16p12.1
 	rdfs:label	"16p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p12.1#GRCh37
+hco:16p12.1\/GRCh37
 	rdf:type	hco:16p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12415,16 +12415,16 @@ hco:16p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p12.1#GRCh38
+hco:16p12.1\/GRCh38
 	rdf:type	hco:16p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12433,12 +12433,12 @@ hco:16p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28500000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12446,7 +12446,7 @@ hco:16p11.2
 	rdfs:label	"16p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p11.2#GRCh37
+hco:16p11.2\/GRCh37
 	rdf:type	hco:16p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12455,16 +12455,16 @@ hco:16p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p11.2#GRCh38
+hco:16p11.2\/GRCh38
 	rdf:type	hco:16p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12473,12 +12473,12 @@ hco:16p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28500000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35300000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12486,7 +12486,7 @@ hco:16p11.1
 	rdfs:label	"16p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16p11.1#GRCh37
+hco:16p11.1\/GRCh37
 	rdf:type	hco:16p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -12495,16 +12495,16 @@ hco:16p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16p11.1#GRCh38
+hco:16p11.1\/GRCh38
 	rdf:type	hco:16p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -12513,12 +12513,12 @@ hco:16p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35300000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12526,7 +12526,7 @@ hco:16q11.1
 	rdfs:label	"16q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q11.1#GRCh37
+hco:16q11.1\/GRCh37
 	rdf:type	hco:16q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -12535,16 +12535,16 @@ hco:16q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q11.1#GRCh38
+hco:16q11.1\/GRCh38
 	rdf:type	hco:16q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -12553,12 +12553,12 @@ hco:16q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12566,7 +12566,7 @@ hco:16q11.2
 	rdfs:label	"16q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q11.2#GRCh37
+hco:16q11.2\/GRCh37
 	rdf:type	hco:16q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -12575,16 +12575,16 @@ hco:16q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47000000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q11.2#GRCh38
+hco:16q11.2\/GRCh38
 	rdf:type	hco:16q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -12593,12 +12593,12 @@ hco:16q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12606,7 +12606,7 @@ hco:16q12.1
 	rdfs:label	"16q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q12.1#GRCh37
+hco:16q12.1\/GRCh37
 	rdf:type	hco:16q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12615,16 +12615,16 @@ hco:16q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47000000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q12.1#GRCh38
+hco:16q12.1\/GRCh38
 	rdf:type	hco:16q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12633,12 +12633,12 @@ hco:16q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12646,7 +12646,7 @@ hco:16q12.2
 	rdfs:label	"16q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q12.2#GRCh37
+hco:16q12.2\/GRCh37
 	rdf:type	hco:16q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12655,16 +12655,16 @@ hco:16q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q12.2#GRCh38
+hco:16q12.2\/GRCh38
 	rdf:type	hco:16q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12673,12 +12673,12 @@ hco:16q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12686,7 +12686,7 @@ hco:16q13
 	rdfs:label	"16q13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q13#GRCh37
+hco:16q13\/GRCh37
 	rdf:type	hco:16q13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12695,16 +12695,16 @@ hco:16q13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57400000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q13#GRCh38
+hco:16q13\/GRCh38
 	rdf:type	hco:16q13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12713,12 +12713,12 @@ hco:16q13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57300000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12726,7 +12726,7 @@ hco:16q21
 	rdfs:label	"16q21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q21#GRCh37
+hco:16q21\/GRCh37
 	rdf:type	hco:16q21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -12735,16 +12735,16 @@ hco:16q21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57400000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q21#GRCh38
+hco:16q21\/GRCh38
 	rdf:type	hco:16q21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -12753,12 +12753,12 @@ hco:16q21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57300000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12766,7 +12766,7 @@ hco:16q22.1
 	rdfs:label	"16q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q22.1#GRCh37
+hco:16q22.1\/GRCh37
 	rdf:type	hco:16q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12775,16 +12775,16 @@ hco:16q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q22.1#GRCh38
+hco:16q22.1\/GRCh38
 	rdf:type	hco:16q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12793,12 +12793,12 @@ hco:16q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12806,7 +12806,7 @@ hco:16q22.2
 	rdfs:label	"16q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q22.2#GRCh37
+hco:16q22.2\/GRCh37
 	rdf:type	hco:16q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12815,16 +12815,16 @@ hco:16q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70800000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72900000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q22.2#GRCh38
+hco:16q22.2\/GRCh38
 	rdf:type	hco:16q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12833,12 +12833,12 @@ hco:16q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12846,7 +12846,7 @@ hco:16q22.3
 	rdfs:label	"16q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q22.3#GRCh37
+hco:16q22.3\/GRCh37
 	rdf:type	hco:16q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12855,16 +12855,16 @@ hco:16q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72900000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q22.3#GRCh38
+hco:16q22.3\/GRCh38
 	rdf:type	hco:16q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12873,12 +12873,12 @@ hco:16q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72800000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12886,7 +12886,7 @@ hco:16q23.1
 	rdfs:label	"16q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q23.1#GRCh37
+hco:16q23.1\/GRCh37
 	rdf:type	hco:16q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -12895,16 +12895,16 @@ hco:16q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q23.1#GRCh38
+hco:16q23.1\/GRCh38
 	rdf:type	hco:16q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -12913,12 +12913,12 @@ hco:16q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12926,7 +12926,7 @@ hco:16q23.2
 	rdfs:label	"16q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q23.2#GRCh37
+hco:16q23.2\/GRCh37
 	rdf:type	hco:16q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -12935,16 +12935,16 @@ hco:16q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q23.2#GRCh38
+hco:16q23.2\/GRCh38
 	rdf:type	hco:16q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -12953,12 +12953,12 @@ hco:16q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -12966,7 +12966,7 @@ hco:16q23.3
 	rdfs:label	"16q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q23.3#GRCh37
+hco:16q23.3\/GRCh37
 	rdf:type	hco:16q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12975,16 +12975,16 @@ hco:16q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q23.3#GRCh38
+hco:16q23.3\/GRCh38
 	rdf:type	hco:16q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -12993,12 +12993,12 @@ hco:16q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81600000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -13006,7 +13006,7 @@ hco:16q24.1
 	rdfs:label	"16q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q24.1#GRCh37
+hco:16q24.1\/GRCh37
 	rdf:type	hco:16q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13015,16 +13015,16 @@ hco:16q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84200000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q24.1#GRCh38
+hco:16q24.1\/GRCh38
 	rdf:type	hco:16q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13033,12 +13033,12 @@ hco:16q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -13046,7 +13046,7 @@ hco:16q24.2
 	rdfs:label	"16q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q24.2#GRCh37
+hco:16q24.2\/GRCh37
 	rdf:type	hco:16q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13055,16 +13055,16 @@ hco:16q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q24.2#GRCh38
+hco:16q24.2\/GRCh38
 	rdf:type	hco:16q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13073,12 +13073,12 @@ hco:16q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87000000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -13086,7 +13086,7 @@ hco:16q24.3
 	rdfs:label	"16q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:16q24.3#GRCh37
+hco:16q24.3\/GRCh37
 	rdf:type	hco:16q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13095,16 +13095,16 @@ hco:16q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88700000 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90354753 ;
-			faldo:reference	hco:16#GRCh37
+			faldo:reference	hco:16\/GRCh37
 		]
 	] .
 
-hco:16q24.3#GRCh38
+hco:16q24.3\/GRCh38
 	rdf:type	hco:16q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13113,12 +13113,12 @@ hco:16q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88700000 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90338345 ;
-			faldo:reference	hco:16#GRCh38
+			faldo:reference	hco:16\/GRCh38
 		]
 	] .
 
@@ -13126,7 +13126,7 @@ hco:17p13.3
 	rdfs:label	"17p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p13.3#GRCh37
+hco:17p13.3\/GRCh37
 	rdf:type	hco:17p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13135,16 +13135,16 @@ hco:17p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p13.3#GRCh38
+hco:17p13.3\/GRCh38
 	rdf:type	hco:17p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13153,12 +13153,12 @@ hco:17p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3400000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13166,7 +13166,7 @@ hco:17p13.2
 	rdfs:label	"17p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p13.2#GRCh37
+hco:17p13.2\/GRCh37
 	rdf:type	hco:17p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13175,16 +13175,16 @@ hco:17p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6500000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p13.2#GRCh38
+hco:17p13.2\/GRCh38
 	rdf:type	hco:17p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13193,12 +13193,12 @@ hco:17p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3400000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13206,7 +13206,7 @@ hco:17p13.1
 	rdfs:label	"17p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p13.1#GRCh37
+hco:17p13.1\/GRCh37
 	rdf:type	hco:17p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13215,16 +13215,16 @@ hco:17p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6500000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10700000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p13.1#GRCh38
+hco:17p13.1\/GRCh38
 	rdf:type	hco:17p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13233,12 +13233,12 @@ hco:17p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13246,7 +13246,7 @@ hco:17p12
 	rdfs:label	"17p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p12#GRCh37
+hco:17p12\/GRCh37
 	rdf:type	hco:17p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13255,16 +13255,16 @@ hco:17p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10700000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16000000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p12#GRCh38
+hco:17p12\/GRCh38
 	rdf:type	hco:17p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13273,12 +13273,12 @@ hco:17p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13286,7 +13286,7 @@ hco:17p11.2
 	rdfs:label	"17p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p11.2#GRCh37
+hco:17p11.2\/GRCh37
 	rdf:type	hco:17p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13295,16 +13295,16 @@ hco:17p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16000000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p11.2#GRCh38
+hco:17p11.2\/GRCh38
 	rdf:type	hco:17p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13313,12 +13313,12 @@ hco:17p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22700000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13326,7 +13326,7 @@ hco:17p11.1
 	rdfs:label	"17p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17p11.1#GRCh37
+hco:17p11.1\/GRCh37
 	rdf:type	hco:17p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -13335,16 +13335,16 @@ hco:17p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17p11.1#GRCh38
+hco:17p11.1\/GRCh38
 	rdf:type	hco:17p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -13353,12 +13353,12 @@ hco:17p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22700000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13366,7 +13366,7 @@ hco:17q11.1
 	rdfs:label	"17q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q11.1#GRCh37
+hco:17q11.1\/GRCh37
 	rdf:type	hco:17q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -13375,16 +13375,16 @@ hco:17q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q11.1#GRCh38
+hco:17q11.1\/GRCh38
 	rdf:type	hco:17q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -13393,12 +13393,12 @@ hco:17q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27400000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13406,7 +13406,7 @@ hco:17q11.2
 	rdfs:label	"17q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q11.2#GRCh37
+hco:17q11.2\/GRCh37
 	rdf:type	hco:17q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13415,16 +13415,16 @@ hco:17q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q11.2#GRCh38
+hco:17q11.2\/GRCh38
 	rdf:type	hco:17q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13433,12 +13433,12 @@ hco:17q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27400000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13446,7 +13446,7 @@ hco:17q12
 	rdfs:label	"17q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q12#GRCh37
+hco:17q12\/GRCh37
 	rdf:type	hco:17q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13455,16 +13455,16 @@ hco:17q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q12#GRCh38
+hco:17q12\/GRCh38
 	rdf:type	hco:17q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13473,12 +13473,12 @@ hco:17q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13486,7 +13486,7 @@ hco:17q21.1
 	rdfs:label	"17q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q21.1#GRCh37
+hco:17q21.1\/GRCh37
 	rdf:type	hco:17q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13495,16 +13495,16 @@ hco:17q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q21.1#GRCh38
+hco:17q21.1\/GRCh38
 	rdf:type	hco:17q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13513,12 +13513,12 @@ hco:17q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13526,7 +13526,7 @@ hco:17q21.2
 	rdfs:label	"17q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q21.2#GRCh37
+hco:17q21.2\/GRCh37
 	rdf:type	hco:17q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13535,16 +13535,16 @@ hco:17q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q21.2#GRCh38
+hco:17q21.2\/GRCh38
 	rdf:type	hco:17q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13553,12 +13553,12 @@ hco:17q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13566,7 +13566,7 @@ hco:17q21.31
 	rdfs:label	"17q21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q21.31#GRCh37
+hco:17q21.31\/GRCh37
 	rdf:type	hco:17q21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13575,16 +13575,16 @@ hco:17q21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q21.31#GRCh38
+hco:17q21.31\/GRCh38
 	rdf:type	hco:17q21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13593,12 +13593,12 @@ hco:17q21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13606,7 +13606,7 @@ hco:17q21.32
 	rdfs:label	"17q21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q21.32#GRCh37
+hco:17q21.32\/GRCh37
 	rdf:type	hco:17q21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13615,16 +13615,16 @@ hco:17q21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47400000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q21.32#GRCh38
+hco:17q21.32\/GRCh38
 	rdf:type	hco:17q21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -13633,12 +13633,12 @@ hco:17q21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49300000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13646,7 +13646,7 @@ hco:17q21.33
 	rdfs:label	"17q21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q21.33#GRCh37
+hco:17q21.33\/GRCh37
 	rdf:type	hco:17q21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13655,16 +13655,16 @@ hco:17q21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47400000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q21.33#GRCh38
+hco:17q21.33\/GRCh38
 	rdf:type	hco:17q21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13673,12 +13673,12 @@ hco:17q21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49300000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13686,7 +13686,7 @@ hco:17q22
 	rdfs:label	"17q22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q22#GRCh37
+hco:17q22\/GRCh37
 	rdf:type	hco:17q22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13695,16 +13695,16 @@ hco:17q22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57600000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q22#GRCh38
+hco:17q22\/GRCh38
 	rdf:type	hco:17q22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13713,12 +13713,12 @@ hco:17q22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13726,7 +13726,7 @@ hco:17q23.1
 	rdfs:label	"17q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q23.1#GRCh37
+hco:17q23.1\/GRCh37
 	rdf:type	hco:17q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13735,16 +13735,16 @@ hco:17q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57600000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q23.1#GRCh38
+hco:17q23.1\/GRCh38
 	rdf:type	hco:17q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13753,12 +13753,12 @@ hco:17q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59500000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13766,7 +13766,7 @@ hco:17q23.2
 	rdfs:label	"17q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q23.2#GRCh37
+hco:17q23.2\/GRCh37
 	rdf:type	hco:17q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13775,16 +13775,16 @@ hco:17q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q23.2#GRCh38
+hco:17q23.2\/GRCh38
 	rdf:type	hco:17q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13793,12 +13793,12 @@ hco:17q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13806,7 +13806,7 @@ hco:17q23.3
 	rdfs:label	"17q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q23.3#GRCh37
+hco:17q23.3\/GRCh37
 	rdf:type	hco:17q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13815,16 +13815,16 @@ hco:17q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62600000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q23.3#GRCh38
+hco:17q23.3\/GRCh38
 	rdf:type	hco:17q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13833,12 +13833,12 @@ hco:17q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64600000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13846,7 +13846,7 @@ hco:17q24.1
 	rdfs:label	"17q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q24.1#GRCh37
+hco:17q24.1\/GRCh37
 	rdf:type	hco:17q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13855,16 +13855,16 @@ hco:17q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62600000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q24.1#GRCh38
+hco:17q24.1\/GRCh38
 	rdf:type	hco:17q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -13873,12 +13873,12 @@ hco:17q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64600000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13886,7 +13886,7 @@ hco:17q24.2
 	rdfs:label	"17q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q24.2#GRCh37
+hco:17q24.2\/GRCh37
 	rdf:type	hco:17q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13895,16 +13895,16 @@ hco:17q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64200000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q24.2#GRCh38
+hco:17q24.2\/GRCh38
 	rdf:type	hco:17q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13913,12 +13913,12 @@ hco:17q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13926,7 +13926,7 @@ hco:17q24.3
 	rdfs:label	"17q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q24.3#GRCh37
+hco:17q24.3\/GRCh37
 	rdf:type	hco:17q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13935,16 +13935,16 @@ hco:17q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67100000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q24.3#GRCh38
+hco:17q24.3\/GRCh38
 	rdf:type	hco:17q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -13953,12 +13953,12 @@ hco:17q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72900000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -13966,7 +13966,7 @@ hco:17q25.1
 	rdfs:label	"17q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q25.1#GRCh37
+hco:17q25.1\/GRCh37
 	rdf:type	hco:17q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -13975,16 +13975,16 @@ hco:17q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70900000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q25.1#GRCh38
+hco:17q25.1\/GRCh38
 	rdf:type	hco:17q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -13993,12 +13993,12 @@ hco:17q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72900000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -14006,7 +14006,7 @@ hco:17q25.2
 	rdfs:label	"17q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q25.2#GRCh37
+hco:17q25.2\/GRCh37
 	rdf:type	hco:17q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14015,16 +14015,16 @@ hco:17q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74800000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q25.2#GRCh38
+hco:17q25.2\/GRCh38
 	rdf:type	hco:17q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14033,12 +14033,12 @@ hco:17q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76800000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -14046,7 +14046,7 @@ hco:17q25.3
 	rdfs:label	"17q25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:17q25.3#GRCh37
+hco:17q25.3\/GRCh37
 	rdf:type	hco:17q25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14055,16 +14055,16 @@ hco:17q25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81195210 ;
-			faldo:reference	hco:17#GRCh37
+			faldo:reference	hco:17\/GRCh37
 		]
 	] .
 
-hco:17q25.3#GRCh38
+hco:17q25.3\/GRCh38
 	rdf:type	hco:17q25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14073,12 +14073,12 @@ hco:17q25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77200000 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83257441 ;
-			faldo:reference	hco:17#GRCh38
+			faldo:reference	hco:17\/GRCh38
 		]
 	] .
 
@@ -14086,7 +14086,7 @@ hco:18p11.32
 	rdfs:label	"18p11.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.32#GRCh37
+hco:18p11.32\/GRCh37
 	rdf:type	hco:18p11.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14095,16 +14095,16 @@ hco:18p11.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2900000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.32#GRCh38
+hco:18p11.32\/GRCh38
 	rdf:type	hco:18p11.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14113,12 +14113,12 @@ hco:18p11.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14126,7 +14126,7 @@ hco:18p11.31
 	rdfs:label	"18p11.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.31#GRCh37
+hco:18p11.31\/GRCh37
 	rdf:type	hco:18p11.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -14135,16 +14135,16 @@ hco:18p11.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2900000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.31#GRCh38
+hco:18p11.31\/GRCh38
 	rdf:type	hco:18p11.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -14153,12 +14153,12 @@ hco:18p11.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14166,7 +14166,7 @@ hco:18p11.23
 	rdfs:label	"18p11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.23#GRCh37
+hco:18p11.23\/GRCh37
 	rdf:type	hco:18p11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14175,16 +14175,16 @@ hco:18p11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8500000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.23#GRCh38
+hco:18p11.23\/GRCh38
 	rdf:type	hco:18p11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14193,12 +14193,12 @@ hco:18p11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14206,7 +14206,7 @@ hco:18p11.22
 	rdfs:label	"18p11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.22#GRCh37
+hco:18p11.22\/GRCh37
 	rdf:type	hco:18p11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14215,16 +14215,16 @@ hco:18p11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8500000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.22#GRCh38
+hco:18p11.22\/GRCh38
 	rdf:type	hco:18p11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14233,12 +14233,12 @@ hco:18p11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14246,7 +14246,7 @@ hco:18p11.21
 	rdfs:label	"18p11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.21#GRCh37
+hco:18p11.21\/GRCh37
 	rdf:type	hco:18p11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14255,16 +14255,16 @@ hco:18p11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15400000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.21#GRCh38
+hco:18p11.21\/GRCh38
 	rdf:type	hco:18p11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14273,12 +14273,12 @@ hco:18p11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15400000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14286,7 +14286,7 @@ hco:18p11.1
 	rdfs:label	"18p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18p11.1#GRCh37
+hco:18p11.1\/GRCh37
 	rdf:type	hco:18p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -14295,16 +14295,16 @@ hco:18p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15400000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18p11.1#GRCh38
+hco:18p11.1\/GRCh38
 	rdf:type	hco:18p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -14313,12 +14313,12 @@ hco:18p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15400000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14326,7 +14326,7 @@ hco:18q11.1
 	rdfs:label	"18q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q11.1#GRCh37
+hco:18q11.1\/GRCh37
 	rdf:type	hco:18q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -14335,16 +14335,16 @@ hco:18q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q11.1#GRCh38
+hco:18q11.1\/GRCh38
 	rdf:type	hco:18q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -14353,12 +14353,12 @@ hco:18q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14366,7 +14366,7 @@ hco:18q11.2
 	rdfs:label	"18q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q11.2#GRCh37
+hco:18q11.2\/GRCh37
 	rdf:type	hco:18q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14375,16 +14375,16 @@ hco:18q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q11.2#GRCh38
+hco:18q11.2\/GRCh38
 	rdf:type	hco:18q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14393,12 +14393,12 @@ hco:18q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14406,7 +14406,7 @@ hco:18q12.1
 	rdfs:label	"18q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q12.1#GRCh37
+hco:18q12.1\/GRCh37
 	rdf:type	hco:18q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -14415,16 +14415,16 @@ hco:18q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32700000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q12.1#GRCh38
+hco:18q12.1\/GRCh38
 	rdf:type	hco:18q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -14433,12 +14433,12 @@ hco:18q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35100000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14446,7 +14446,7 @@ hco:18q12.2
 	rdfs:label	"18q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q12.2#GRCh37
+hco:18q12.2\/GRCh37
 	rdf:type	hco:18q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14455,16 +14455,16 @@ hco:18q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32700000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q12.2#GRCh38
+hco:18q12.2\/GRCh38
 	rdf:type	hco:18q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14473,12 +14473,12 @@ hco:18q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35100000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14486,7 +14486,7 @@ hco:18q12.3
 	rdfs:label	"18q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q12.3#GRCh37
+hco:18q12.3\/GRCh37
 	rdf:type	hco:18q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -14495,16 +14495,16 @@ hco:18q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q12.3#GRCh38
+hco:18q12.3\/GRCh38
 	rdf:type	hco:18q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -14513,12 +14513,12 @@ hco:18q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39500000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14526,7 +14526,7 @@ hco:18q21.1
 	rdfs:label	"18q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q21.1#GRCh37
+hco:18q21.1\/GRCh37
 	rdf:type	hco:18q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14535,16 +14535,16 @@ hco:18q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q21.1#GRCh38
+hco:18q21.1\/GRCh38
 	rdf:type	hco:18q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14553,12 +14553,12 @@ hco:18q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14566,7 +14566,7 @@ hco:18q21.2
 	rdfs:label	"18q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q21.2#GRCh37
+hco:18q21.2\/GRCh37
 	rdf:type	hco:18q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -14575,16 +14575,16 @@ hco:18q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53800000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q21.2#GRCh38
+hco:18q21.2\/GRCh38
 	rdf:type	hco:18q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -14593,12 +14593,12 @@ hco:18q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14606,7 +14606,7 @@ hco:18q21.31
 	rdfs:label	"18q21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q21.31#GRCh37
+hco:18q21.31\/GRCh37
 	rdf:type	hco:18q21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14615,16 +14615,16 @@ hco:18q21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53800000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q21.31#GRCh38
+hco:18q21.31\/GRCh38
 	rdf:type	hco:18q21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14633,12 +14633,12 @@ hco:18q21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14646,7 +14646,7 @@ hco:18q21.32
 	rdfs:label	"18q21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q21.32#GRCh37
+hco:18q21.32\/GRCh37
 	rdf:type	hco:18q21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -14655,16 +14655,16 @@ hco:18q21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56200000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q21.32#GRCh38
+hco:18q21.32\/GRCh38
 	rdf:type	hco:18q21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -14673,12 +14673,12 @@ hco:18q21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14686,7 +14686,7 @@ hco:18q21.33
 	rdfs:label	"18q21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q21.33#GRCh37
+hco:18q21.33\/GRCh37
 	rdf:type	hco:18q21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14695,16 +14695,16 @@ hco:18q21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59000000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q21.33#GRCh38
+hco:18q21.33\/GRCh38
 	rdf:type	hco:18q21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14713,12 +14713,12 @@ hco:18q21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14726,7 +14726,7 @@ hco:18q22.1
 	rdfs:label	"18q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q22.1#GRCh37
+hco:18q22.1\/GRCh37
 	rdf:type	hco:18q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -14735,16 +14735,16 @@ hco:18q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66800000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q22.1#GRCh38
+hco:18q22.1\/GRCh38
 	rdf:type	hco:18q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -14753,12 +14753,12 @@ hco:18q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14766,7 +14766,7 @@ hco:18q22.2
 	rdfs:label	"18q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q22.2#GRCh37
+hco:18q22.2\/GRCh37
 	rdf:type	hco:18q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14775,16 +14775,16 @@ hco:18q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66800000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q22.2#GRCh38
+hco:18q22.2\/GRCh38
 	rdf:type	hco:18q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14793,12 +14793,12 @@ hco:18q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71000000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14806,7 +14806,7 @@ hco:18q22.3
 	rdfs:label	"18q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q22.3#GRCh37
+hco:18q22.3\/GRCh37
 	rdf:type	hco:18q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14815,16 +14815,16 @@ hco:18q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73100000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q22.3#GRCh38
+hco:18q22.3\/GRCh38
 	rdf:type	hco:18q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14833,12 +14833,12 @@ hco:18q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71000000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75400000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14846,7 +14846,7 @@ hco:18q23
 	rdfs:label	"18q23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:18q23#GRCh37
+hco:18q23\/GRCh37
 	rdf:type	hco:18q23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14855,16 +14855,16 @@ hco:18q23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73100000 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78077248 ;
-			faldo:reference	hco:18#GRCh37
+			faldo:reference	hco:18\/GRCh37
 		]
 	] .
 
-hco:18q23#GRCh38
+hco:18q23\/GRCh38
 	rdf:type	hco:18q23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14873,12 +14873,12 @@ hco:18q23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75400000 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80373285 ;
-			faldo:reference	hco:18#GRCh38
+			faldo:reference	hco:18\/GRCh38
 		]
 	] .
 
@@ -14886,7 +14886,7 @@ hco:19p13.3
 	rdfs:label	"19p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p13.3#GRCh37
+hco:19p13.3\/GRCh37
 	rdf:type	hco:19p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14895,16 +14895,16 @@ hco:19p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p13.3#GRCh38
+hco:19p13.3\/GRCh38
 	rdf:type	hco:19p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14913,12 +14913,12 @@ hco:19p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -14926,7 +14926,7 @@ hco:19p13.2
 	rdfs:label	"19p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p13.2#GRCh37
+hco:19p13.2\/GRCh37
 	rdf:type	hco:19p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14935,16 +14935,16 @@ hco:19p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13900000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p13.2#GRCh38
+hco:19p13.2\/GRCh38
 	rdf:type	hco:19p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -14953,12 +14953,12 @@ hco:19p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -14966,7 +14966,7 @@ hco:19p13.13
 	rdfs:label	"19p13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p13.13#GRCh37
+hco:19p13.13\/GRCh37
 	rdf:type	hco:19p13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -14975,16 +14975,16 @@ hco:19p13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13900000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p13.13#GRCh38
+hco:19p13.13\/GRCh38
 	rdf:type	hco:19p13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -14993,12 +14993,12 @@ hco:19p13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12600000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15006,7 +15006,7 @@ hco:19p13.12
 	rdfs:label	"19p13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p13.12#GRCh37
+hco:19p13.12\/GRCh37
 	rdf:type	hco:19p13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15015,16 +15015,16 @@ hco:19p13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p13.12#GRCh38
+hco:19p13.12\/GRCh38
 	rdf:type	hco:19p13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15033,12 +15033,12 @@ hco:19p13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15046,7 +15046,7 @@ hco:19p13.11
 	rdfs:label	"19p13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p13.11#GRCh37
+hco:19p13.11\/GRCh37
 	rdf:type	hco:19p13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15055,16 +15055,16 @@ hco:19p13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p13.11#GRCh38
+hco:19p13.11\/GRCh38
 	rdf:type	hco:19p13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15073,12 +15073,12 @@ hco:19p13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15086,7 +15086,7 @@ hco:19p12
 	rdfs:label	"19p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p12#GRCh37
+hco:19p12\/GRCh37
 	rdf:type	hco:19p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -15095,16 +15095,16 @@ hco:19p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p12#GRCh38
+hco:19p12\/GRCh38
 	rdf:type	hco:19p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -15113,12 +15113,12 @@ hco:19p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15126,7 +15126,7 @@ hco:19p11
 	rdfs:label	"19p11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19p11#GRCh37
+hco:19p11\/GRCh37
 	rdf:type	hco:19p11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -15135,16 +15135,16 @@ hco:19p11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26500000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19p11#GRCh38
+hco:19p11\/GRCh38
 	rdf:type	hco:19p11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -15153,12 +15153,12 @@ hco:19p11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15166,7 +15166,7 @@ hco:19q11
 	rdfs:label	"19q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q11#GRCh37
+hco:19q11\/GRCh37
 	rdf:type	hco:19q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -15175,16 +15175,16 @@ hco:19q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26500000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28600000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q11#GRCh38
+hco:19q11\/GRCh38
 	rdf:type	hco:19q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -15193,12 +15193,12 @@ hco:19q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15206,7 +15206,7 @@ hco:19q12
 	rdfs:label	"19q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q12#GRCh37
+hco:19q12\/GRCh37
 	rdf:type	hco:19q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -15215,16 +15215,16 @@ hco:19q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28600000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q12#GRCh38
+hco:19q12\/GRCh38
 	rdf:type	hco:19q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -15233,12 +15233,12 @@ hco:19q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15246,7 +15246,7 @@ hco:19q13.11
 	rdfs:label	"19q13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.11#GRCh37
+hco:19q13.11\/GRCh37
 	rdf:type	hco:19q13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15255,16 +15255,16 @@ hco:19q13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.11#GRCh38
+hco:19q13.11\/GRCh38
 	rdf:type	hco:19q13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15273,12 +15273,12 @@ hco:19q13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15286,7 +15286,7 @@ hco:19q13.12
 	rdfs:label	"19q13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.12#GRCh37
+hco:19q13.12\/GRCh37
 	rdf:type	hco:19q13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15295,16 +15295,16 @@ hco:19q13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35500000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.12#GRCh38
+hco:19q13.12\/GRCh38
 	rdf:type	hco:19q13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15313,12 +15313,12 @@ hco:19q13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15326,7 +15326,7 @@ hco:19q13.13
 	rdfs:label	"19q13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.13#GRCh37
+hco:19q13.13\/GRCh37
 	rdf:type	hco:19q13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15335,16 +15335,16 @@ hco:19q13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38700000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.13#GRCh38
+hco:19q13.13\/GRCh38
 	rdf:type	hco:19q13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15353,12 +15353,12 @@ hco:19q13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15366,7 +15366,7 @@ hco:19q13.2
 	rdfs:label	"19q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.2#GRCh37
+hco:19q13.2\/GRCh37
 	rdf:type	hco:19q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15375,16 +15375,16 @@ hco:19q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38700000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.2#GRCh38
+hco:19q13.2\/GRCh38
 	rdf:type	hco:19q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15393,12 +15393,12 @@ hco:19q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38200000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15406,7 +15406,7 @@ hco:19q13.31
 	rdfs:label	"19q13.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.31#GRCh37
+hco:19q13.31\/GRCh37
 	rdf:type	hco:19q13.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15415,16 +15415,16 @@ hco:19q13.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.31#GRCh38
+hco:19q13.31\/GRCh38
 	rdf:type	hco:19q13.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15433,12 +15433,12 @@ hco:19q13.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44700000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15446,7 +15446,7 @@ hco:19q13.32
 	rdfs:label	"19q13.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.32#GRCh37
+hco:19q13.32\/GRCh37
 	rdf:type	hco:19q13.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15455,16 +15455,16 @@ hco:19q13.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.32#GRCh38
+hco:19q13.32\/GRCh38
 	rdf:type	hco:19q13.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15473,12 +15473,12 @@ hco:19q13.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44700000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47500000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15486,7 +15486,7 @@ hco:19q13.33
 	rdfs:label	"19q13.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.33#GRCh37
+hco:19q13.33\/GRCh37
 	rdf:type	hco:19q13.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15495,16 +15495,16 @@ hco:19q13.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48000000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.33#GRCh38
+hco:19q13.33\/GRCh38
 	rdf:type	hco:19q13.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15513,12 +15513,12 @@ hco:19q13.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47500000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15526,7 +15526,7 @@ hco:19q13.41
 	rdfs:label	"19q13.41" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.41#GRCh37
+hco:19q13.41\/GRCh37
 	rdf:type	hco:19q13.41 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15535,16 +15535,16 @@ hco:19q13.41#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51400000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53600000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.41#GRCh38
+hco:19q13.41\/GRCh38
 	rdf:type	hco:19q13.41 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15553,12 +15553,12 @@ hco:19q13.41#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50900000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15566,7 +15566,7 @@ hco:19q13.42
 	rdfs:label	"19q13.42" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.42#GRCh37
+hco:19q13.42\/GRCh37
 	rdf:type	hco:19q13.42 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15575,16 +15575,16 @@ hco:19q13.42#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53600000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.42#GRCh38
+hco:19q13.42\/GRCh38
 	rdf:type	hco:19q13.42 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15593,12 +15593,12 @@ hco:19q13.42#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53100000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15606,7 +15606,7 @@ hco:19q13.43
 	rdfs:label	"19q13.43" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:19q13.43#GRCh37
+hco:19q13.43\/GRCh37
 	rdf:type	hco:19q13.43 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15615,16 +15615,16 @@ hco:19q13.43#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56300000 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59128983 ;
-			faldo:reference	hco:19#GRCh37
+			faldo:reference	hco:19\/GRCh37
 		]
 	] .
 
-hco:19q13.43#GRCh38
+hco:19q13.43\/GRCh38
 	rdf:type	hco:19q13.43 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15633,12 +15633,12 @@ hco:19q13.43#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55800000 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58617616 ;
-			faldo:reference	hco:19#GRCh38
+			faldo:reference	hco:19\/GRCh38
 		]
 	] .
 
@@ -15646,7 +15646,7 @@ hco:2p25.3
 	rdfs:label	"2p25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p25.3#GRCh37
+hco:2p25.3\/GRCh37
 	rdf:type	hco:2p25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15655,16 +15655,16 @@ hco:2p25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p25.3#GRCh38
+hco:2p25.3\/GRCh38
 	rdf:type	hco:2p25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15673,12 +15673,12 @@ hco:2p25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15686,7 +15686,7 @@ hco:2p25.2
 	rdfs:label	"2p25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p25.2#GRCh37
+hco:2p25.2\/GRCh37
 	rdf:type	hco:2p25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -15695,16 +15695,16 @@ hco:2p25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p25.2#GRCh38
+hco:2p25.2\/GRCh38
 	rdf:type	hco:2p25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -15713,12 +15713,12 @@ hco:2p25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15726,7 +15726,7 @@ hco:2p25.1
 	rdfs:label	"2p25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p25.1#GRCh37
+hco:2p25.1\/GRCh37
 	rdf:type	hco:2p25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15735,16 +15735,16 @@ hco:2p25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p25.1#GRCh38
+hco:2p25.1\/GRCh38
 	rdf:type	hco:2p25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15753,12 +15753,12 @@ hco:2p25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15766,7 +15766,7 @@ hco:2p24.3
 	rdfs:label	"2p24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p24.3#GRCh37
+hco:2p24.3\/GRCh37
 	rdf:type	hco:2p24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -15775,16 +15775,16 @@ hco:2p24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p24.3#GRCh38
+hco:2p24.3\/GRCh38
 	rdf:type	hco:2p24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -15793,12 +15793,12 @@ hco:2p24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15806,7 +15806,7 @@ hco:2p24.2
 	rdfs:label	"2p24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p24.2#GRCh37
+hco:2p24.2\/GRCh37
 	rdf:type	hco:2p24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15815,16 +15815,16 @@ hco:2p24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p24.2#GRCh38
+hco:2p24.2\/GRCh38
 	rdf:type	hco:2p24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15833,12 +15833,12 @@ hco:2p24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15846,7 +15846,7 @@ hco:2p24.1
 	rdfs:label	"2p24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p24.1#GRCh37
+hco:2p24.1\/GRCh37
 	rdf:type	hco:2p24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -15855,16 +15855,16 @@ hco:2p24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p24.1#GRCh38
+hco:2p24.1\/GRCh38
 	rdf:type	hco:2p24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -15873,12 +15873,12 @@ hco:2p24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15886,7 +15886,7 @@ hco:2p23.3
 	rdfs:label	"2p23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p23.3#GRCh37
+hco:2p23.3\/GRCh37
 	rdf:type	hco:2p23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15895,16 +15895,16 @@ hco:2p23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p23.3#GRCh38
+hco:2p23.3\/GRCh38
 	rdf:type	hco:2p23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15913,12 +15913,12 @@ hco:2p23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15926,7 +15926,7 @@ hco:2p23.2
 	rdfs:label	"2p23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p23.2#GRCh37
+hco:2p23.2\/GRCh37
 	rdf:type	hco:2p23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15935,16 +15935,16 @@ hco:2p23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p23.2#GRCh38
+hco:2p23.2\/GRCh38
 	rdf:type	hco:2p23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -15953,12 +15953,12 @@ hco:2p23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -15966,7 +15966,7 @@ hco:2p23.1
 	rdfs:label	"2p23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p23.1#GRCh37
+hco:2p23.1\/GRCh37
 	rdf:type	hco:2p23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -15975,16 +15975,16 @@ hco:2p23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p23.1#GRCh38
+hco:2p23.1\/GRCh38
 	rdf:type	hco:2p23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -15993,12 +15993,12 @@ hco:2p23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16006,7 +16006,7 @@ hco:2p22.3
 	rdfs:label	"2p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p22.3#GRCh37
+hco:2p22.3\/GRCh37
 	rdf:type	hco:2p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -16015,16 +16015,16 @@ hco:2p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p22.3#GRCh38
+hco:2p22.3\/GRCh38
 	rdf:type	hco:2p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -16033,12 +16033,12 @@ hco:2p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16046,7 +16046,7 @@ hco:2p22.2
 	rdfs:label	"2p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p22.2#GRCh37
+hco:2p22.2\/GRCh37
 	rdf:type	hco:2p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16055,16 +16055,16 @@ hco:2p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p22.2#GRCh38
+hco:2p22.2\/GRCh38
 	rdf:type	hco:2p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16073,12 +16073,12 @@ hco:2p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16086,7 +16086,7 @@ hco:2p22.1
 	rdfs:label	"2p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p22.1#GRCh37
+hco:2p22.1\/GRCh37
 	rdf:type	hco:2p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16095,16 +16095,16 @@ hco:2p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p22.1#GRCh38
+hco:2p22.1\/GRCh38
 	rdf:type	hco:2p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16113,12 +16113,12 @@ hco:2p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16126,7 +16126,7 @@ hco:2p21
 	rdfs:label	"2p21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p21#GRCh37
+hco:2p21\/GRCh37
 	rdf:type	hco:2p21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16135,16 +16135,16 @@ hco:2p21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p21#GRCh38
+hco:2p21\/GRCh38
 	rdf:type	hco:2p21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16153,12 +16153,12 @@ hco:2p21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16166,7 +16166,7 @@ hco:2p16.3
 	rdfs:label	"2p16.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p16.3#GRCh37
+hco:2p16.3\/GRCh37
 	rdf:type	hco:2p16.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16175,16 +16175,16 @@ hco:2p16.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p16.3#GRCh38
+hco:2p16.3\/GRCh38
 	rdf:type	hco:2p16.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16193,12 +16193,12 @@ hco:2p16.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16206,7 +16206,7 @@ hco:2p16.2
 	rdfs:label	"2p16.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p16.2#GRCh37
+hco:2p16.2\/GRCh37
 	rdf:type	hco:2p16.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16215,16 +16215,16 @@ hco:2p16.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p16.2#GRCh38
+hco:2p16.2\/GRCh38
 	rdf:type	hco:2p16.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16233,12 +16233,12 @@ hco:2p16.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16246,7 +16246,7 @@ hco:2p16.1
 	rdfs:label	"2p16.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p16.1#GRCh37
+hco:2p16.1\/GRCh37
 	rdf:type	hco:2p16.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16255,16 +16255,16 @@ hco:2p16.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p16.1#GRCh38
+hco:2p16.1\/GRCh38
 	rdf:type	hco:2p16.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16273,12 +16273,12 @@ hco:2p16.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16286,7 +16286,7 @@ hco:2p15
 	rdfs:label	"2p15" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p15#GRCh37
+hco:2p15\/GRCh37
 	rdf:type	hco:2p15 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16295,16 +16295,16 @@ hco:2p15#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p15#GRCh38
+hco:2p15\/GRCh38
 	rdf:type	hco:2p15 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16313,12 +16313,12 @@ hco:2p15#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16326,7 +16326,7 @@ hco:2p14
 	rdfs:label	"2p14" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p14#GRCh37
+hco:2p14\/GRCh37
 	rdf:type	hco:2p14 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16335,16 +16335,16 @@ hco:2p14#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p14#GRCh38
+hco:2p14\/GRCh38
 	rdf:type	hco:2p14 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16353,12 +16353,12 @@ hco:2p14#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16366,7 +16366,7 @@ hco:2p13.3
 	rdfs:label	"2p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p13.3#GRCh37
+hco:2p13.3\/GRCh37
 	rdf:type	hco:2p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16375,16 +16375,16 @@ hco:2p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p13.3#GRCh38
+hco:2p13.3\/GRCh38
 	rdf:type	hco:2p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16393,12 +16393,12 @@ hco:2p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16406,7 +16406,7 @@ hco:2p13.2
 	rdfs:label	"2p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p13.2#GRCh37
+hco:2p13.2\/GRCh37
 	rdf:type	hco:2p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16415,16 +16415,16 @@ hco:2p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p13.2#GRCh38
+hco:2p13.2\/GRCh38
 	rdf:type	hco:2p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16433,12 +16433,12 @@ hco:2p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16446,7 +16446,7 @@ hco:2p13.1
 	rdfs:label	"2p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p13.1#GRCh37
+hco:2p13.1\/GRCh37
 	rdf:type	hco:2p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16455,16 +16455,16 @@ hco:2p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p13.1#GRCh38
+hco:2p13.1\/GRCh38
 	rdf:type	hco:2p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16473,12 +16473,12 @@ hco:2p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16486,7 +16486,7 @@ hco:2p12
 	rdfs:label	"2p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p12#GRCh37
+hco:2p12\/GRCh37
 	rdf:type	hco:2p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16495,16 +16495,16 @@ hco:2p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p12#GRCh38
+hco:2p12\/GRCh38
 	rdf:type	hco:2p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -16513,12 +16513,12 @@ hco:2p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16526,7 +16526,7 @@ hco:2p11.2
 	rdfs:label	"2p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p11.2#GRCh37
+hco:2p11.2\/GRCh37
 	rdf:type	hco:2p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16535,16 +16535,16 @@ hco:2p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p11.2#GRCh38
+hco:2p11.2\/GRCh38
 	rdf:type	hco:2p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16553,12 +16553,12 @@ hco:2p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16566,7 +16566,7 @@ hco:2p11.1
 	rdfs:label	"2p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2p11.1#GRCh37
+hco:2p11.1\/GRCh37
 	rdf:type	hco:2p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -16575,16 +16575,16 @@ hco:2p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2p11.1#GRCh38
+hco:2p11.1\/GRCh38
 	rdf:type	hco:2p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -16593,12 +16593,12 @@ hco:2p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16606,7 +16606,7 @@ hco:2q11.1
 	rdfs:label	"2q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q11.1#GRCh37
+hco:2q11.1\/GRCh37
 	rdf:type	hco:2q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -16615,16 +16615,16 @@ hco:2q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q11.1#GRCh38
+hco:2q11.1\/GRCh38
 	rdf:type	hco:2q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -16633,12 +16633,12 @@ hco:2q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16646,7 +16646,7 @@ hco:2q11.2
 	rdfs:label	"2q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q11.2#GRCh37
+hco:2q11.2\/GRCh37
 	rdf:type	hco:2q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16655,16 +16655,16 @@ hco:2q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q11.2#GRCh38
+hco:2q11.2\/GRCh38
 	rdf:type	hco:2q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16673,12 +16673,12 @@ hco:2q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16686,7 +16686,7 @@ hco:2q12.1
 	rdfs:label	"2q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q12.1#GRCh37
+hco:2q12.1\/GRCh37
 	rdf:type	hco:2q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16695,16 +16695,16 @@ hco:2q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q12.1#GRCh38
+hco:2q12.1\/GRCh38
 	rdf:type	hco:2q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16713,12 +16713,12 @@ hco:2q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16726,7 +16726,7 @@ hco:2q12.2
 	rdfs:label	"2q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q12.2#GRCh37
+hco:2q12.2\/GRCh37
 	rdf:type	hco:2q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16735,16 +16735,16 @@ hco:2q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q12.2#GRCh38
+hco:2q12.2\/GRCh38
 	rdf:type	hco:2q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16753,12 +16753,12 @@ hco:2q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16766,7 +16766,7 @@ hco:2q12.3
 	rdfs:label	"2q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q12.3#GRCh37
+hco:2q12.3\/GRCh37
 	rdf:type	hco:2q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -16775,16 +16775,16 @@ hco:2q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q12.3#GRCh38
+hco:2q12.3\/GRCh38
 	rdf:type	hco:2q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -16793,12 +16793,12 @@ hco:2q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16806,7 +16806,7 @@ hco:2q13
 	rdfs:label	"2q13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q13#GRCh37
+hco:2q13\/GRCh37
 	rdf:type	hco:2q13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16815,16 +16815,16 @@ hco:2q13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q13#GRCh38
+hco:2q13\/GRCh38
 	rdf:type	hco:2q13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16833,12 +16833,12 @@ hco:2q13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16846,7 +16846,7 @@ hco:2q14.1
 	rdfs:label	"2q14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q14.1#GRCh37
+hco:2q14.1\/GRCh37
 	rdf:type	hco:2q14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16855,16 +16855,16 @@ hco:2q14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q14.1#GRCh38
+hco:2q14.1\/GRCh38
 	rdf:type	hco:2q14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16873,12 +16873,12 @@ hco:2q14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16886,7 +16886,7 @@ hco:2q14.2
 	rdfs:label	"2q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q14.2#GRCh37
+hco:2q14.2\/GRCh37
 	rdf:type	hco:2q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16895,16 +16895,16 @@ hco:2q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q14.2#GRCh38
+hco:2q14.2\/GRCh38
 	rdf:type	hco:2q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16913,12 +16913,12 @@ hco:2q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16926,7 +16926,7 @@ hco:2q14.3
 	rdfs:label	"2q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q14.3#GRCh37
+hco:2q14.3\/GRCh37
 	rdf:type	hco:2q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16935,16 +16935,16 @@ hco:2q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q14.3#GRCh38
+hco:2q14.3\/GRCh38
 	rdf:type	hco:2q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -16953,12 +16953,12 @@ hco:2q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -16966,7 +16966,7 @@ hco:2q21.1
 	rdfs:label	"2q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q21.1#GRCh37
+hco:2q21.1\/GRCh37
 	rdf:type	hco:2q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -16975,16 +16975,16 @@ hco:2q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q21.1#GRCh38
+hco:2q21.1\/GRCh38
 	rdf:type	hco:2q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -16993,12 +16993,12 @@ hco:2q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17006,7 +17006,7 @@ hco:2q21.2
 	rdfs:label	"2q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q21.2#GRCh37
+hco:2q21.2\/GRCh37
 	rdf:type	hco:2q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -17015,16 +17015,16 @@ hco:2q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q21.2#GRCh38
+hco:2q21.2\/GRCh38
 	rdf:type	hco:2q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -17033,12 +17033,12 @@ hco:2q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17046,7 +17046,7 @@ hco:2q21.3
 	rdfs:label	"2q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q21.3#GRCh37
+hco:2q21.3\/GRCh37
 	rdf:type	hco:2q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17055,16 +17055,16 @@ hco:2q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q21.3#GRCh38
+hco:2q21.3\/GRCh38
 	rdf:type	hco:2q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17073,12 +17073,12 @@ hco:2q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17086,7 +17086,7 @@ hco:2q22.1
 	rdfs:label	"2q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q22.1#GRCh37
+hco:2q22.1\/GRCh37
 	rdf:type	hco:2q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17095,16 +17095,16 @@ hco:2q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q22.1#GRCh38
+hco:2q22.1\/GRCh38
 	rdf:type	hco:2q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17113,12 +17113,12 @@ hco:2q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17126,7 +17126,7 @@ hco:2q22.2
 	rdfs:label	"2q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q22.2#GRCh37
+hco:2q22.2\/GRCh37
 	rdf:type	hco:2q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17135,16 +17135,16 @@ hco:2q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	144100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q22.2#GRCh38
+hco:2q22.2\/GRCh38
 	rdf:type	hco:2q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17153,12 +17153,12 @@ hco:2q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17166,7 +17166,7 @@ hco:2q22.3
 	rdfs:label	"2q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q22.3#GRCh37
+hco:2q22.3\/GRCh37
 	rdf:type	hco:2q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17175,16 +17175,16 @@ hco:2q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	144100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q22.3#GRCh38
+hco:2q22.3\/GRCh38
 	rdf:type	hco:2q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17193,12 +17193,12 @@ hco:2q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17206,7 +17206,7 @@ hco:2q23.1
 	rdfs:label	"2q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q23.1#GRCh37
+hco:2q23.1\/GRCh37
 	rdf:type	hco:2q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17215,16 +17215,16 @@ hco:2q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q23.1#GRCh38
+hco:2q23.1\/GRCh38
 	rdf:type	hco:2q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17233,12 +17233,12 @@ hco:2q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17246,7 +17246,7 @@ hco:2q23.2
 	rdfs:label	"2q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q23.2#GRCh37
+hco:2q23.2\/GRCh37
 	rdf:type	hco:2q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -17255,16 +17255,16 @@ hco:2q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q23.2#GRCh38
+hco:2q23.2\/GRCh38
 	rdf:type	hco:2q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -17273,12 +17273,12 @@ hco:2q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17286,7 +17286,7 @@ hco:2q23.3
 	rdfs:label	"2q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q23.3#GRCh37
+hco:2q23.3\/GRCh37
 	rdf:type	hco:2q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17295,16 +17295,16 @@ hco:2q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q23.3#GRCh38
+hco:2q23.3\/GRCh38
 	rdf:type	hco:2q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17313,12 +17313,12 @@ hco:2q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17326,7 +17326,7 @@ hco:2q24.1
 	rdfs:label	"2q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q24.1#GRCh37
+hco:2q24.1\/GRCh37
 	rdf:type	hco:2q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17335,16 +17335,16 @@ hco:2q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q24.1#GRCh38
+hco:2q24.1\/GRCh38
 	rdf:type	hco:2q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17353,12 +17353,12 @@ hco:2q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154000000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	158900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17366,7 +17366,7 @@ hco:2q24.2
 	rdfs:label	"2q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q24.2#GRCh37
+hco:2q24.2\/GRCh37
 	rdf:type	hco:2q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17375,16 +17375,16 @@ hco:2q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159800000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	163700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q24.2#GRCh38
+hco:2q24.2\/GRCh38
 	rdf:type	hco:2q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17393,12 +17393,12 @@ hco:2q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	158900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	162900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17406,7 +17406,7 @@ hco:2q24.3
 	rdfs:label	"2q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q24.3#GRCh37
+hco:2q24.3\/GRCh37
 	rdf:type	hco:2q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17415,16 +17415,16 @@ hco:2q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	163700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q24.3#GRCh38
+hco:2q24.3\/GRCh38
 	rdf:type	hco:2q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17433,12 +17433,12 @@ hco:2q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	162900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	168900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17446,7 +17446,7 @@ hco:2q31.1
 	rdfs:label	"2q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q31.1#GRCh37
+hco:2q31.1\/GRCh37
 	rdf:type	hco:2q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17455,16 +17455,16 @@ hco:2q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169700000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	178000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q31.1#GRCh38
+hco:2q31.1\/GRCh38
 	rdf:type	hco:2q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17473,12 +17473,12 @@ hco:2q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	168900000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17486,7 +17486,7 @@ hco:2q31.2
 	rdfs:label	"2q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q31.2#GRCh37
+hco:2q31.2\/GRCh37
 	rdf:type	hco:2q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -17495,16 +17495,16 @@ hco:2q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	178000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q31.2#GRCh38
+hco:2q31.2\/GRCh38
 	rdf:type	hco:2q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -17513,12 +17513,12 @@ hco:2q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17526,7 +17526,7 @@ hco:2q31.3
 	rdfs:label	"2q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q31.3#GRCh37
+hco:2q31.3\/GRCh37
 	rdf:type	hco:2q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17535,16 +17535,16 @@ hco:2q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q31.3#GRCh38
+hco:2q31.3\/GRCh38
 	rdf:type	hco:2q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17553,12 +17553,12 @@ hco:2q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17566,7 +17566,7 @@ hco:2q32.1
 	rdfs:label	"2q32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q32.1#GRCh37
+hco:2q32.1\/GRCh37
 	rdf:type	hco:2q32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17575,16 +17575,16 @@ hco:2q32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	189400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q32.1#GRCh38
+hco:2q32.1\/GRCh38
 	rdf:type	hco:2q32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17593,12 +17593,12 @@ hco:2q32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	188500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17606,7 +17606,7 @@ hco:2q32.2
 	rdfs:label	"2q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q32.2#GRCh37
+hco:2q32.2\/GRCh37
 	rdf:type	hco:2q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17615,16 +17615,16 @@ hco:2q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	189400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	191900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q32.2#GRCh38
+hco:2q32.2\/GRCh38
 	rdf:type	hco:2q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17633,12 +17633,12 @@ hco:2q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	188500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	191100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17646,7 +17646,7 @@ hco:2q32.3
 	rdfs:label	"2q32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q32.3#GRCh37
+hco:2q32.3\/GRCh37
 	rdf:type	hco:2q32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17655,16 +17655,16 @@ hco:2q32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	191900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	197400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q32.3#GRCh38
+hco:2q32.3\/GRCh38
 	rdf:type	hco:2q32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17673,12 +17673,12 @@ hco:2q32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	191100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	196600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17686,7 +17686,7 @@ hco:2q33.1
 	rdfs:label	"2q33.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q33.1#GRCh37
+hco:2q33.1\/GRCh37
 	rdf:type	hco:2q33.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17695,16 +17695,16 @@ hco:2q33.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	197400000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	203300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q33.1#GRCh38
+hco:2q33.1\/GRCh38
 	rdf:type	hco:2q33.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17713,12 +17713,12 @@ hco:2q33.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	196600000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	202500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17726,7 +17726,7 @@ hco:2q33.2
 	rdfs:label	"2q33.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q33.2#GRCh37
+hco:2q33.2\/GRCh37
 	rdf:type	hco:2q33.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -17735,16 +17735,16 @@ hco:2q33.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	203300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	204900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q33.2#GRCh38
+hco:2q33.2\/GRCh38
 	rdf:type	hco:2q33.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -17753,12 +17753,12 @@ hco:2q33.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	202500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	204100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17766,7 +17766,7 @@ hco:2q33.3
 	rdfs:label	"2q33.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q33.3#GRCh37
+hco:2q33.3\/GRCh37
 	rdf:type	hco:2q33.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17775,16 +17775,16 @@ hco:2q33.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	204900000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	209000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q33.3#GRCh38
+hco:2q33.3\/GRCh38
 	rdf:type	hco:2q33.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17793,12 +17793,12 @@ hco:2q33.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	204100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	208200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17806,7 +17806,7 @@ hco:2q34
 	rdfs:label	"2q34" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q34#GRCh37
+hco:2q34\/GRCh37
 	rdf:type	hco:2q34 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17815,16 +17815,16 @@ hco:2q34#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	209000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	215300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q34#GRCh38
+hco:2q34\/GRCh38
 	rdf:type	hco:2q34 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17833,12 +17833,12 @@ hco:2q34#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	208200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17846,7 +17846,7 @@ hco:2q35
 	rdfs:label	"2q35" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q35#GRCh37
+hco:2q35\/GRCh37
 	rdf:type	hco:2q35 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17855,16 +17855,16 @@ hco:2q35#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	215300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	221500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q35#GRCh38
+hco:2q35\/GRCh38
 	rdf:type	hco:2q35 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17873,12 +17873,12 @@ hco:2q35#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	214500000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	220700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17886,7 +17886,7 @@ hco:2q36.1
 	rdfs:label	"2q36.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q36.1#GRCh37
+hco:2q36.1\/GRCh37
 	rdf:type	hco:2q36.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17895,16 +17895,16 @@ hco:2q36.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	221500000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	225200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q36.1#GRCh38
+hco:2q36.1\/GRCh38
 	rdf:type	hco:2q36.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -17913,12 +17913,12 @@ hco:2q36.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	220700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17926,7 +17926,7 @@ hco:2q36.2
 	rdfs:label	"2q36.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q36.2#GRCh37
+hco:2q36.2\/GRCh37
 	rdf:type	hco:2q36.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -17935,16 +17935,16 @@ hco:2q36.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	225200000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	226100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q36.2#GRCh38
+hco:2q36.2\/GRCh38
 	rdf:type	hco:2q36.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -17953,12 +17953,12 @@ hco:2q36.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	224300000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	225200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -17966,7 +17966,7 @@ hco:2q36.3
 	rdfs:label	"2q36.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q36.3#GRCh37
+hco:2q36.3\/GRCh37
 	rdf:type	hco:2q36.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17975,16 +17975,16 @@ hco:2q36.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	226100000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	231000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q36.3#GRCh38
+hco:2q36.3\/GRCh38
 	rdf:type	hco:2q36.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -17993,12 +17993,12 @@ hco:2q36.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	225200000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -18006,7 +18006,7 @@ hco:2q37.1
 	rdfs:label	"2q37.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q37.1#GRCh37
+hco:2q37.1\/GRCh37
 	rdf:type	hco:2q37.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18015,16 +18015,16 @@ hco:2q37.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	231000000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	235600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q37.1#GRCh38
+hco:2q37.1\/GRCh38
 	rdf:type	hco:2q37.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18033,12 +18033,12 @@ hco:2q37.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	230100000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -18046,7 +18046,7 @@ hco:2q37.2
 	rdfs:label	"2q37.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q37.2#GRCh37
+hco:2q37.2\/GRCh37
 	rdf:type	hco:2q37.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -18055,16 +18055,16 @@ hco:2q37.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	235600000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	237300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q37.2#GRCh38
+hco:2q37.2\/GRCh38
 	rdf:type	hco:2q37.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -18073,12 +18073,12 @@ hco:2q37.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	234700000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -18086,7 +18086,7 @@ hco:2q37.3
 	rdfs:label	"2q37.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:2q37.3#GRCh37
+hco:2q37.3\/GRCh37
 	rdf:type	hco:2q37.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18095,16 +18095,16 @@ hco:2q37.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	237300000 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	243199373 ;
-			faldo:reference	hco:2#GRCh37
+			faldo:reference	hco:2\/GRCh37
 		]
 	] .
 
-hco:2q37.3#GRCh38
+hco:2q37.3\/GRCh38
 	rdf:type	hco:2q37.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18113,12 +18113,12 @@ hco:2q37.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	236400000 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	242193529 ;
-			faldo:reference	hco:2#GRCh38
+			faldo:reference	hco:2\/GRCh38
 		]
 	] .
 
@@ -18126,7 +18126,7 @@ hco:20p13
 	rdfs:label	"20p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p13#GRCh37
+hco:20p13\/GRCh37
 	rdf:type	hco:20p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18135,16 +18135,16 @@ hco:20p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p13#GRCh38
+hco:20p13\/GRCh38
 	rdf:type	hco:20p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18153,12 +18153,12 @@ hco:20p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18166,7 +18166,7 @@ hco:20p12.3
 	rdfs:label	"20p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p12.3#GRCh37
+hco:20p12.3\/GRCh37
 	rdf:type	hco:20p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18175,16 +18175,16 @@ hco:20p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p12.3#GRCh38
+hco:20p12.3\/GRCh38
 	rdf:type	hco:20p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18193,12 +18193,12 @@ hco:20p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	5100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18206,7 +18206,7 @@ hco:20p12.2
 	rdfs:label	"20p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p12.2#GRCh37
+hco:20p12.2\/GRCh37
 	rdf:type	hco:20p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18215,16 +18215,16 @@ hco:20p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p12.2#GRCh38
+hco:20p12.2\/GRCh38
 	rdf:type	hco:20p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18233,12 +18233,12 @@ hco:20p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9200000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18246,7 +18246,7 @@ hco:20p12.1
 	rdfs:label	"20p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p12.1#GRCh37
+hco:20p12.1\/GRCh37
 	rdf:type	hco:20p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18255,16 +18255,16 @@ hco:20p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p12.1#GRCh38
+hco:20p12.1\/GRCh38
 	rdf:type	hco:20p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18273,12 +18273,12 @@ hco:20p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18286,7 +18286,7 @@ hco:20p11.23
 	rdfs:label	"20p11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p11.23#GRCh37
+hco:20p11.23\/GRCh37
 	rdf:type	hco:20p11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18295,16 +18295,16 @@ hco:20p11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p11.23#GRCh38
+hco:20p11.23\/GRCh38
 	rdf:type	hco:20p11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18313,12 +18313,12 @@ hco:20p11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18326,7 +18326,7 @@ hco:20p11.22
 	rdfs:label	"20p11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p11.22#GRCh37
+hco:20p11.22\/GRCh37
 	rdf:type	hco:20p11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18335,16 +18335,16 @@ hco:20p11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p11.22#GRCh38
+hco:20p11.22\/GRCh38
 	rdf:type	hco:20p11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18353,12 +18353,12 @@ hco:20p11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18366,7 +18366,7 @@ hco:20p11.21
 	rdfs:label	"20p11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p11.21#GRCh37
+hco:20p11.21\/GRCh37
 	rdf:type	hco:20p11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18375,16 +18375,16 @@ hco:20p11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p11.21#GRCh38
+hco:20p11.21\/GRCh38
 	rdf:type	hco:20p11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18393,12 +18393,12 @@ hco:20p11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22300000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25700000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18406,7 +18406,7 @@ hco:20p11.1
 	rdfs:label	"20p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20p11.1#GRCh37
+hco:20p11.1\/GRCh37
 	rdf:type	hco:20p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -18415,16 +18415,16 @@ hco:20p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20p11.1#GRCh38
+hco:20p11.1\/GRCh38
 	rdf:type	hco:20p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -18433,12 +18433,12 @@ hco:20p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25700000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18446,7 +18446,7 @@ hco:20q11.1
 	rdfs:label	"20q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q11.1#GRCh37
+hco:20q11.1\/GRCh37
 	rdf:type	hco:20q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -18455,16 +18455,16 @@ hco:20q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q11.1#GRCh38
+hco:20q11.1\/GRCh38
 	rdf:type	hco:20q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -18473,12 +18473,12 @@ hco:20q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30400000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18486,7 +18486,7 @@ hco:20q11.21
 	rdfs:label	"20q11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q11.21#GRCh37
+hco:20q11.21\/GRCh37
 	rdf:type	hco:20q11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18495,16 +18495,16 @@ hco:20q11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q11.21#GRCh38
+hco:20q11.21\/GRCh38
 	rdf:type	hco:20q11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18513,12 +18513,12 @@ hco:20q11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30400000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18526,7 +18526,7 @@ hco:20q11.22
 	rdfs:label	"20q11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q11.22#GRCh37
+hco:20q11.22\/GRCh37
 	rdf:type	hco:20q11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18535,16 +18535,16 @@ hco:20q11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q11.22#GRCh38
+hco:20q11.22\/GRCh38
 	rdf:type	hco:20q11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18553,12 +18553,12 @@ hco:20q11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18566,7 +18566,7 @@ hco:20q11.23
 	rdfs:label	"20q11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q11.23#GRCh37
+hco:20q11.23\/GRCh37
 	rdf:type	hco:20q11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18575,16 +18575,16 @@ hco:20q11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q11.23#GRCh38
+hco:20q11.23\/GRCh38
 	rdf:type	hco:20q11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18593,12 +18593,12 @@ hco:20q11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39000000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18606,7 +18606,7 @@ hco:20q12
 	rdfs:label	"20q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q12#GRCh37
+hco:20q12\/GRCh37
 	rdf:type	hco:20q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18615,16 +18615,16 @@ hco:20q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41700000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q12#GRCh38
+hco:20q12\/GRCh38
 	rdf:type	hco:20q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18633,12 +18633,12 @@ hco:20q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39000000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18646,7 +18646,7 @@ hco:20q13.11
 	rdfs:label	"20q13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.11#GRCh37
+hco:20q13.11\/GRCh37
 	rdf:type	hco:20q13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18655,16 +18655,16 @@ hco:20q13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41700000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.11#GRCh38
+hco:20q13.11\/GRCh38
 	rdf:type	hco:20q13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18673,12 +18673,12 @@ hco:20q13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43100000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18686,7 +18686,7 @@ hco:20q13.12
 	rdfs:label	"20q13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.12#GRCh37
+hco:20q13.12\/GRCh37
 	rdf:type	hco:20q13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18695,16 +18695,16 @@ hco:20q13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42100000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.12#GRCh38
+hco:20q13.12\/GRCh38
 	rdf:type	hco:20q13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -18713,12 +18713,12 @@ hco:20q13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43500000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18726,7 +18726,7 @@ hco:20q13.13
 	rdfs:label	"20q13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.13#GRCh37
+hco:20q13.13\/GRCh37
 	rdf:type	hco:20q13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18735,16 +18735,16 @@ hco:20q13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49800000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.13#GRCh38
+hco:20q13.13\/GRCh38
 	rdf:type	hco:20q13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18753,12 +18753,12 @@ hco:20q13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51200000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18766,7 +18766,7 @@ hco:20q13.2
 	rdfs:label	"20q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.2#GRCh37
+hco:20q13.2\/GRCh37
 	rdf:type	hco:20q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18775,16 +18775,16 @@ hco:20q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49800000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.2#GRCh38
+hco:20q13.2\/GRCh38
 	rdf:type	hco:20q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -18793,12 +18793,12 @@ hco:20q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51200000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56400000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18806,7 +18806,7 @@ hco:20q13.31
 	rdfs:label	"20q13.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.31#GRCh37
+hco:20q13.31\/GRCh37
 	rdf:type	hco:20q13.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18815,16 +18815,16 @@ hco:20q13.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55000000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56500000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.31#GRCh38
+hco:20q13.31\/GRCh38
 	rdf:type	hco:20q13.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18833,12 +18833,12 @@ hco:20q13.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56400000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18846,7 +18846,7 @@ hco:20q13.32
 	rdfs:label	"20q13.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.32#GRCh37
+hco:20q13.32\/GRCh37
 	rdf:type	hco:20q13.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -18855,16 +18855,16 @@ hco:20q13.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	56500000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.32#GRCh38
+hco:20q13.32\/GRCh38
 	rdf:type	hco:20q13.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -18873,12 +18873,12 @@ hco:20q13.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57800000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59700000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18886,7 +18886,7 @@ hco:20q13.33
 	rdfs:label	"20q13.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:20q13.33#GRCh37
+hco:20q13.33\/GRCh37
 	rdf:type	hco:20q13.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -18895,16 +18895,16 @@ hco:20q13.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58400000 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63025520 ;
-			faldo:reference	hco:20#GRCh37
+			faldo:reference	hco:20\/GRCh37
 		]
 	] .
 
-hco:20q13.33#GRCh38
+hco:20q13.33\/GRCh38
 	rdf:type	hco:20q13.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -18913,12 +18913,12 @@ hco:20q13.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59700000 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64444167 ;
-			faldo:reference	hco:20#GRCh38
+			faldo:reference	hco:20\/GRCh38
 		]
 	] .
 
@@ -18926,7 +18926,7 @@ hco:21p13
 	rdfs:label	"21p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21p13#GRCh37
+hco:21p13\/GRCh37
 	rdf:type	hco:21p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -18935,16 +18935,16 @@ hco:21p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21p13#GRCh38
+hco:21p13\/GRCh38
 	rdf:type	hco:21p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -18953,12 +18953,12 @@ hco:21p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3100000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -18966,7 +18966,7 @@ hco:21p12
 	rdfs:label	"21p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21p12#GRCh37
+hco:21p12\/GRCh37
 	rdf:type	hco:21p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Stalk ;
@@ -18975,16 +18975,16 @@ hco:21p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21p12#GRCh38
+hco:21p12\/GRCh38
 	rdf:type	hco:21p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Stalk ;
@@ -18993,12 +18993,12 @@ hco:21p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3100000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19006,7 +19006,7 @@ hco:21p11.2
 	rdfs:label	"21p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21p11.2#GRCh37
+hco:21p11.2\/GRCh37
 	rdf:type	hco:21p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -19015,16 +19015,16 @@ hco:21p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21p11.2#GRCh38
+hco:21p11.2\/GRCh38
 	rdf:type	hco:21p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -19033,12 +19033,12 @@ hco:21p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19046,7 +19046,7 @@ hco:21p11.1
 	rdfs:label	"21p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21p11.1#GRCh37
+hco:21p11.1\/GRCh37
 	rdf:type	hco:21p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -19055,16 +19055,16 @@ hco:21p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13200000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21p11.1#GRCh38
+hco:21p11.1\/GRCh38
 	rdf:type	hco:21p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -19073,12 +19073,12 @@ hco:21p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10900000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19086,7 +19086,7 @@ hco:21q11.1
 	rdfs:label	"21q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q11.1#GRCh37
+hco:21q11.1\/GRCh37
 	rdf:type	hco:21q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -19095,16 +19095,16 @@ hco:21q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13200000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14300000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q11.1#GRCh38
+hco:21q11.1\/GRCh38
 	rdf:type	hco:21q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -19113,12 +19113,12 @@ hco:21q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19126,7 +19126,7 @@ hco:21q11.2
 	rdfs:label	"21q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q11.2#GRCh37
+hco:21q11.2\/GRCh37
 	rdf:type	hco:21q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19135,16 +19135,16 @@ hco:21q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14300000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16400000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q11.2#GRCh38
+hco:21q11.2\/GRCh38
 	rdf:type	hco:21q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19153,12 +19153,12 @@ hco:21q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19166,7 +19166,7 @@ hco:21q21.1
 	rdfs:label	"21q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q21.1#GRCh37
+hco:21q21.1\/GRCh37
 	rdf:type	hco:21q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -19175,16 +19175,16 @@ hco:21q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16400000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q21.1#GRCh38
+hco:21q21.1\/GRCh38
 	rdf:type	hco:21q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -19193,12 +19193,12 @@ hco:21q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19206,7 +19206,7 @@ hco:21q21.2
 	rdfs:label	"21q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q21.2#GRCh37
+hco:21q21.2\/GRCh37
 	rdf:type	hco:21q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19215,16 +19215,16 @@ hco:21q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24000000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q21.2#GRCh38
+hco:21q21.2\/GRCh38
 	rdf:type	hco:21q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19233,12 +19233,12 @@ hco:21q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22600000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19246,7 +19246,7 @@ hco:21q21.3
 	rdfs:label	"21q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q21.3#GRCh37
+hco:21q21.3\/GRCh37
 	rdf:type	hco:21q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -19255,16 +19255,16 @@ hco:21q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q21.3#GRCh38
+hco:21q21.3\/GRCh38
 	rdf:type	hco:21q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -19273,12 +19273,12 @@ hco:21q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30200000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19286,7 +19286,7 @@ hco:21q22.11
 	rdfs:label	"21q22.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q22.11#GRCh37
+hco:21q22.11\/GRCh37
 	rdf:type	hco:21q22.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19295,16 +19295,16 @@ hco:21q22.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q22.11#GRCh38
+hco:21q22.11\/GRCh38
 	rdf:type	hco:21q22.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19313,12 +19313,12 @@ hco:21q22.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30200000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19326,7 +19326,7 @@ hco:21q22.12
 	rdfs:label	"21q22.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q22.12#GRCh37
+hco:21q22.12\/GRCh37
 	rdf:type	hco:21q22.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19335,16 +19335,16 @@ hco:21q22.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q22.12#GRCh38
+hco:21q22.12\/GRCh38
 	rdf:type	hco:21q22.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19353,12 +19353,12 @@ hco:21q22.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34400000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19366,7 +19366,7 @@ hco:21q22.13
 	rdfs:label	"21q22.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q22.13#GRCh37
+hco:21q22.13\/GRCh37
 	rdf:type	hco:21q22.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19375,16 +19375,16 @@ hco:21q22.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39700000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q22.13#GRCh38
+hco:21q22.13\/GRCh38
 	rdf:type	hco:21q22.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19393,12 +19393,12 @@ hco:21q22.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19406,7 +19406,7 @@ hco:21q22.2
 	rdfs:label	"21q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q22.2#GRCh37
+hco:21q22.2\/GRCh37
 	rdf:type	hco:21q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19415,16 +19415,16 @@ hco:21q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39700000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42600000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q22.2#GRCh38
+hco:21q22.2\/GRCh38
 	rdf:type	hco:21q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19433,12 +19433,12 @@ hco:21q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19446,7 +19446,7 @@ hco:21q22.3
 	rdfs:label	"21q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:21q22.3#GRCh37
+hco:21q22.3\/GRCh37
 	rdf:type	hco:21q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19455,16 +19455,16 @@ hco:21q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42600000 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48129895 ;
-			faldo:reference	hco:21#GRCh37
+			faldo:reference	hco:21\/GRCh37
 		]
 	] .
 
-hco:21q22.3#GRCh38
+hco:21q22.3\/GRCh38
 	rdf:type	hco:21q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19473,12 +19473,12 @@ hco:21q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46709983 ;
-			faldo:reference	hco:21#GRCh38
+			faldo:reference	hco:21\/GRCh38
 		]
 	] .
 
@@ -19486,7 +19486,7 @@ hco:22p13
 	rdfs:label	"22p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22p13#GRCh37
+hco:22p13\/GRCh37
 	rdf:type	hco:22p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -19495,16 +19495,16 @@ hco:22p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22p13#GRCh38
+hco:22p13\/GRCh38
 	rdf:type	hco:22p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -19513,12 +19513,12 @@ hco:22p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4300000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19526,7 +19526,7 @@ hco:22p12
 	rdfs:label	"22p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22p12#GRCh37
+hco:22p12\/GRCh37
 	rdf:type	hco:22p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Stalk ;
@@ -19535,16 +19535,16 @@ hco:22p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3800000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8300000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22p12#GRCh38
+hco:22p12\/GRCh38
 	rdf:type	hco:22p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Stalk ;
@@ -19553,12 +19553,12 @@ hco:22p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4300000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9400000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19566,7 +19566,7 @@ hco:22p11.2
 	rdfs:label	"22p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22p11.2#GRCh37
+hco:22p11.2\/GRCh37
 	rdf:type	hco:22p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -19575,16 +19575,16 @@ hco:22p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8300000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22p11.2#GRCh38
+hco:22p11.2\/GRCh38
 	rdf:type	hco:22p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -19593,12 +19593,12 @@ hco:22p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9400000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13700000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19606,7 +19606,7 @@ hco:22p11.1
 	rdfs:label	"22p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22p11.1#GRCh37
+hco:22p11.1\/GRCh37
 	rdf:type	hco:22p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -19615,16 +19615,16 @@ hco:22p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14700000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22p11.1#GRCh38
+hco:22p11.1\/GRCh38
 	rdf:type	hco:22p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -19633,12 +19633,12 @@ hco:22p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13700000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19646,7 +19646,7 @@ hco:22q11.1
 	rdfs:label	"22q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q11.1#GRCh37
+hco:22q11.1\/GRCh37
 	rdf:type	hco:22q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -19655,16 +19655,16 @@ hco:22q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14700000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q11.1#GRCh38
+hco:22q11.1\/GRCh38
 	rdf:type	hco:22q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -19673,12 +19673,12 @@ hco:22q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17400000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19686,7 +19686,7 @@ hco:22q11.21
 	rdfs:label	"22q11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q11.21#GRCh37
+hco:22q11.21\/GRCh37
 	rdf:type	hco:22q11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19695,16 +19695,16 @@ hco:22q11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17900000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q11.21#GRCh38
+hco:22q11.21\/GRCh38
 	rdf:type	hco:22q11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19713,12 +19713,12 @@ hco:22q11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17400000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21700000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19726,7 +19726,7 @@ hco:22q11.22
 	rdfs:label	"22q11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q11.22#GRCh37
+hco:22q11.22\/GRCh37
 	rdf:type	hco:22q11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -19735,16 +19735,16 @@ hco:22q11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23500000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q11.22#GRCh38
+hco:22q11.22\/GRCh38
 	rdf:type	hco:22q11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -19753,12 +19753,12 @@ hco:22q11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21700000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19766,7 +19766,7 @@ hco:22q11.23
 	rdfs:label	"22q11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q11.23#GRCh37
+hco:22q11.23\/GRCh37
 	rdf:type	hco:22q11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19775,16 +19775,16 @@ hco:22q11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23500000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25900000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q11.23#GRCh38
+hco:22q11.23\/GRCh38
 	rdf:type	hco:22q11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19793,12 +19793,12 @@ hco:22q11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19806,7 +19806,7 @@ hco:22q12.1
 	rdfs:label	"22q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q12.1#GRCh37
+hco:22q12.1\/GRCh37
 	rdf:type	hco:22q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19815,16 +19815,16 @@ hco:22q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25900000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29600000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q12.1#GRCh38
+hco:22q12.1\/GRCh38
 	rdf:type	hco:22q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19833,12 +19833,12 @@ hco:22q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29200000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19846,7 +19846,7 @@ hco:22q12.2
 	rdfs:label	"22q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q12.2#GRCh37
+hco:22q12.2\/GRCh37
 	rdf:type	hco:22q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19855,16 +19855,16 @@ hco:22q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29600000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q12.2#GRCh38
+hco:22q12.2\/GRCh38
 	rdf:type	hco:22q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19873,12 +19873,12 @@ hco:22q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29200000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19886,7 +19886,7 @@ hco:22q12.3
 	rdfs:label	"22q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q12.3#GRCh37
+hco:22q12.3\/GRCh37
 	rdf:type	hco:22q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19895,16 +19895,16 @@ hco:22q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q12.3#GRCh38
+hco:22q12.3\/GRCh38
 	rdf:type	hco:22q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19913,12 +19913,12 @@ hco:22q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31800000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19926,7 +19926,7 @@ hco:22q13.1
 	rdfs:label	"22q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q13.1#GRCh37
+hco:22q13.1\/GRCh37
 	rdf:type	hco:22q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -19935,16 +19935,16 @@ hco:22q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41000000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q13.1#GRCh38
+hco:22q13.1\/GRCh38
 	rdf:type	hco:22q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -19953,12 +19953,12 @@ hco:22q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40600000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -19966,7 +19966,7 @@ hco:22q13.2
 	rdfs:label	"22q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q13.2#GRCh37
+hco:22q13.2\/GRCh37
 	rdf:type	hco:22q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19975,16 +19975,16 @@ hco:22q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41000000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q13.2#GRCh38
+hco:22q13.2\/GRCh38
 	rdf:type	hco:22q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -19993,12 +19993,12 @@ hco:22q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40600000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43800000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -20006,7 +20006,7 @@ hco:22q13.31
 	rdfs:label	"22q13.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q13.31#GRCh37
+hco:22q13.31\/GRCh37
 	rdf:type	hco:22q13.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20015,16 +20015,16 @@ hco:22q13.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48400000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q13.31#GRCh38
+hco:22q13.31\/GRCh38
 	rdf:type	hco:22q13.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20033,12 +20033,12 @@ hco:22q13.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43800000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -20046,7 +20046,7 @@ hco:22q13.32
 	rdfs:label	"22q13.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q13.32#GRCh37
+hco:22q13.32\/GRCh37
 	rdf:type	hco:22q13.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20055,16 +20055,16 @@ hco:22q13.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48400000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49400000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q13.32#GRCh38
+hco:22q13.32\/GRCh38
 	rdf:type	hco:22q13.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20073,12 +20073,12 @@ hco:22q13.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -20086,7 +20086,7 @@ hco:22q13.33
 	rdfs:label	"22q13.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:22q13.33#GRCh37
+hco:22q13.33\/GRCh37
 	rdf:type	hco:22q13.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20095,16 +20095,16 @@ hco:22q13.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49400000 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51304566 ;
-			faldo:reference	hco:22#GRCh37
+			faldo:reference	hco:22\/GRCh37
 		]
 	] .
 
-hco:22q13.33#GRCh38
+hco:22q13.33\/GRCh38
 	rdf:type	hco:22q13.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20113,12 +20113,12 @@ hco:22q13.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49100000 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50818468 ;
-			faldo:reference	hco:22#GRCh38
+			faldo:reference	hco:22\/GRCh38
 		]
 	] .
 
@@ -20126,7 +20126,7 @@ hco:3p26.3
 	rdfs:label	"3p26.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p26.3#GRCh37
+hco:3p26.3\/GRCh37
 	rdf:type	hco:3p26.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20135,16 +20135,16 @@ hco:3p26.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p26.3#GRCh38
+hco:3p26.3\/GRCh38
 	rdf:type	hco:3p26.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20153,12 +20153,12 @@ hco:3p26.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20166,7 +20166,7 @@ hco:3p26.2
 	rdfs:label	"3p26.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p26.2#GRCh37
+hco:3p26.2\/GRCh37
 	rdf:type	hco:3p26.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20175,16 +20175,16 @@ hco:3p26.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p26.2#GRCh38
+hco:3p26.2\/GRCh38
 	rdf:type	hco:3p26.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20193,12 +20193,12 @@ hco:3p26.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20206,7 +20206,7 @@ hco:3p26.1
 	rdfs:label	"3p26.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p26.1#GRCh37
+hco:3p26.1\/GRCh37
 	rdf:type	hco:3p26.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20215,16 +20215,16 @@ hco:3p26.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p26.1#GRCh38
+hco:3p26.1\/GRCh38
 	rdf:type	hco:3p26.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20233,12 +20233,12 @@ hco:3p26.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20246,7 +20246,7 @@ hco:3p25.3
 	rdfs:label	"3p25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p25.3#GRCh37
+hco:3p25.3\/GRCh37
 	rdf:type	hco:3p25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20255,16 +20255,16 @@ hco:3p25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p25.3#GRCh38
+hco:3p25.3\/GRCh38
 	rdf:type	hco:3p25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20273,12 +20273,12 @@ hco:3p25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	8100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20286,7 +20286,7 @@ hco:3p25.2
 	rdfs:label	"3p25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p25.2#GRCh37
+hco:3p25.2\/GRCh37
 	rdf:type	hco:3p25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -20295,16 +20295,16 @@ hco:3p25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p25.2#GRCh38
+hco:3p25.2\/GRCh38
 	rdf:type	hco:3p25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -20313,12 +20313,12 @@ hco:3p25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20326,7 +20326,7 @@ hco:3p25.1
 	rdfs:label	"3p25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p25.1#GRCh37
+hco:3p25.1\/GRCh37
 	rdf:type	hco:3p25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20335,16 +20335,16 @@ hco:3p25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p25.1#GRCh38
+hco:3p25.1\/GRCh38
 	rdf:type	hco:3p25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20353,12 +20353,12 @@ hco:3p25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20366,7 +20366,7 @@ hco:3p24.3
 	rdfs:label	"3p24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p24.3#GRCh37
+hco:3p24.3\/GRCh37
 	rdf:type	hco:3p24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -20375,16 +20375,16 @@ hco:3p24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p24.3#GRCh38
+hco:3p24.3\/GRCh38
 	rdf:type	hco:3p24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -20393,12 +20393,12 @@ hco:3p24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20406,7 +20406,7 @@ hco:3p24.2
 	rdfs:label	"3p24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p24.2#GRCh37
+hco:3p24.2\/GRCh37
 	rdf:type	hco:3p24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20415,16 +20415,16 @@ hco:3p24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p24.2#GRCh38
+hco:3p24.2\/GRCh38
 	rdf:type	hco:3p24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20433,12 +20433,12 @@ hco:3p24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20446,7 +20446,7 @@ hco:3p24.1
 	rdfs:label	"3p24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p24.1#GRCh37
+hco:3p24.1\/GRCh37
 	rdf:type	hco:3p24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -20455,16 +20455,16 @@ hco:3p24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p24.1#GRCh38
+hco:3p24.1\/GRCh38
 	rdf:type	hco:3p24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -20473,12 +20473,12 @@ hco:3p24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20486,7 +20486,7 @@ hco:3p23
 	rdfs:label	"3p23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p23#GRCh37
+hco:3p23\/GRCh37
 	rdf:type	hco:3p23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20495,16 +20495,16 @@ hco:3p23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p23#GRCh38
+hco:3p23\/GRCh38
 	rdf:type	hco:3p23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20513,12 +20513,12 @@ hco:3p23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20526,7 +20526,7 @@ hco:3p22.3
 	rdfs:label	"3p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p22.3#GRCh37
+hco:3p22.3\/GRCh37
 	rdf:type	hco:3p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20535,16 +20535,16 @@ hco:3p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p22.3#GRCh38
+hco:3p22.3\/GRCh38
 	rdf:type	hco:3p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20553,12 +20553,12 @@ hco:3p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20566,7 +20566,7 @@ hco:3p22.2
 	rdfs:label	"3p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p22.2#GRCh37
+hco:3p22.2\/GRCh37
 	rdf:type	hco:3p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20575,16 +20575,16 @@ hco:3p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p22.2#GRCh38
+hco:3p22.2\/GRCh38
 	rdf:type	hco:3p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20593,12 +20593,12 @@ hco:3p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36400000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20606,7 +20606,7 @@ hco:3p22.1
 	rdfs:label	"3p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p22.1#GRCh37
+hco:3p22.1\/GRCh37
 	rdf:type	hco:3p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -20615,16 +20615,16 @@ hco:3p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p22.1#GRCh38
+hco:3p22.1\/GRCh38
 	rdf:type	hco:3p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -20633,12 +20633,12 @@ hco:3p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20646,7 +20646,7 @@ hco:3p21.33
 	rdfs:label	"3p21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p21.33#GRCh37
+hco:3p21.33\/GRCh37
 	rdf:type	hco:3p21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20655,16 +20655,16 @@ hco:3p21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p21.33#GRCh38
+hco:3p21.33\/GRCh38
 	rdf:type	hco:3p21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20673,12 +20673,12 @@ hco:3p21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20686,7 +20686,7 @@ hco:3p21.32
 	rdfs:label	"3p21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p21.32#GRCh37
+hco:3p21.32\/GRCh37
 	rdf:type	hco:3p21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20695,16 +20695,16 @@ hco:3p21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p21.32#GRCh38
+hco:3p21.32\/GRCh38
 	rdf:type	hco:3p21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20713,12 +20713,12 @@ hco:3p21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20726,7 +20726,7 @@ hco:3p21.31
 	rdfs:label	"3p21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p21.31#GRCh37
+hco:3p21.31\/GRCh37
 	rdf:type	hco:3p21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20735,16 +20735,16 @@ hco:3p21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p21.31#GRCh38
+hco:3p21.31\/GRCh38
 	rdf:type	hco:3p21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20753,12 +20753,12 @@ hco:3p21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20766,7 +20766,7 @@ hco:3p21.2
 	rdfs:label	"3p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p21.2#GRCh37
+hco:3p21.2\/GRCh37
 	rdf:type	hco:3p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -20775,16 +20775,16 @@ hco:3p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p21.2#GRCh38
+hco:3p21.2\/GRCh38
 	rdf:type	hco:3p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -20793,12 +20793,12 @@ hco:3p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20806,7 +20806,7 @@ hco:3p21.1
 	rdfs:label	"3p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p21.1#GRCh37
+hco:3p21.1\/GRCh37
 	rdf:type	hco:3p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20815,16 +20815,16 @@ hco:3p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p21.1#GRCh38
+hco:3p21.1\/GRCh38
 	rdf:type	hco:3p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20833,12 +20833,12 @@ hco:3p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54400000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20846,7 +20846,7 @@ hco:3p14.3
 	rdfs:label	"3p14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p14.3#GRCh37
+hco:3p14.3\/GRCh37
 	rdf:type	hco:3p14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20855,16 +20855,16 @@ hco:3p14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54400000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p14.3#GRCh38
+hco:3p14.3\/GRCh38
 	rdf:type	hco:3p14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20873,12 +20873,12 @@ hco:3p14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54400000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20886,7 +20886,7 @@ hco:3p14.2
 	rdfs:label	"3p14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p14.2#GRCh37
+hco:3p14.2\/GRCh37
 	rdf:type	hco:3p14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20895,16 +20895,16 @@ hco:3p14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p14.2#GRCh38
+hco:3p14.2\/GRCh38
 	rdf:type	hco:3p14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20913,12 +20913,12 @@ hco:3p14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20926,7 +20926,7 @@ hco:3p14.1
 	rdfs:label	"3p14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p14.1#GRCh37
+hco:3p14.1\/GRCh37
 	rdf:type	hco:3p14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20935,16 +20935,16 @@ hco:3p14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p14.1#GRCh38
+hco:3p14.1\/GRCh38
 	rdf:type	hco:3p14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -20953,12 +20953,12 @@ hco:3p14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69700000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -20966,7 +20966,7 @@ hco:3p13
 	rdfs:label	"3p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p13#GRCh37
+hco:3p13\/GRCh37
 	rdf:type	hco:3p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -20975,16 +20975,16 @@ hco:3p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p13#GRCh38
+hco:3p13\/GRCh38
 	rdf:type	hco:3p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -20993,12 +20993,12 @@ hco:3p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69700000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21006,7 +21006,7 @@ hco:3p12.3
 	rdfs:label	"3p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p12.3#GRCh37
+hco:3p12.3\/GRCh37
 	rdf:type	hco:3p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21015,16 +21015,16 @@ hco:3p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p12.3#GRCh38
+hco:3p12.3\/GRCh38
 	rdf:type	hco:3p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21033,12 +21033,12 @@ hco:3p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21046,7 +21046,7 @@ hco:3p12.2
 	rdfs:label	"3p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p12.2#GRCh37
+hco:3p12.2\/GRCh37
 	rdf:type	hco:3p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21055,16 +21055,16 @@ hco:3p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p12.2#GRCh38
+hco:3p12.2\/GRCh38
 	rdf:type	hco:3p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21073,12 +21073,12 @@ hco:3p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21086,7 +21086,7 @@ hco:3p12.1
 	rdfs:label	"3p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p12.1#GRCh37
+hco:3p12.1\/GRCh37
 	rdf:type	hco:3p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21095,16 +21095,16 @@ hco:3p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p12.1#GRCh38
+hco:3p12.1\/GRCh38
 	rdf:type	hco:3p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21113,12 +21113,12 @@ hco:3p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21126,7 +21126,7 @@ hco:3p11.2
 	rdfs:label	"3p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p11.2#GRCh37
+hco:3p11.2\/GRCh37
 	rdf:type	hco:3p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21135,16 +21135,16 @@ hco:3p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p11.2#GRCh38
+hco:3p11.2\/GRCh38
 	rdf:type	hco:3p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21153,12 +21153,12 @@ hco:3p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21166,7 +21166,7 @@ hco:3p11.1
 	rdfs:label	"3p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3p11.1#GRCh37
+hco:3p11.1\/GRCh37
 	rdf:type	hco:3p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -21175,16 +21175,16 @@ hco:3p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3p11.1#GRCh38
+hco:3p11.1\/GRCh38
 	rdf:type	hco:3p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -21193,12 +21193,12 @@ hco:3p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90900000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21206,7 +21206,7 @@ hco:3q11.1
 	rdfs:label	"3q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q11.1#GRCh37
+hco:3q11.1\/GRCh37
 	rdf:type	hco:3q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -21215,16 +21215,16 @@ hco:3q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q11.1#GRCh38
+hco:3q11.1\/GRCh38
 	rdf:type	hco:3q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -21233,12 +21233,12 @@ hco:3q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90900000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21246,7 +21246,7 @@ hco:3q11.2
 	rdfs:label	"3q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q11.2#GRCh37
+hco:3q11.2\/GRCh37
 	rdf:type	hco:3q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -21255,16 +21255,16 @@ hco:3q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q11.2#GRCh38
+hco:3q11.2\/GRCh38
 	rdf:type	hco:3q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -21273,12 +21273,12 @@ hco:3q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21286,7 +21286,7 @@ hco:3q12.1
 	rdfs:label	"3q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q12.1#GRCh37
+hco:3q12.1\/GRCh37
 	rdf:type	hco:3q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21295,16 +21295,16 @@ hco:3q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q12.1#GRCh38
+hco:3q12.1\/GRCh38
 	rdf:type	hco:3q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21313,12 +21313,12 @@ hco:3q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21326,7 +21326,7 @@ hco:3q12.2
 	rdfs:label	"3q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q12.2#GRCh37
+hco:3q12.2\/GRCh37
 	rdf:type	hco:3q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21335,16 +21335,16 @@ hco:3q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q12.2#GRCh38
+hco:3q12.2\/GRCh38
 	rdf:type	hco:3q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21353,12 +21353,12 @@ hco:3q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21366,7 +21366,7 @@ hco:3q12.3
 	rdfs:label	"3q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q12.3#GRCh37
+hco:3q12.3\/GRCh37
 	rdf:type	hco:3q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21375,16 +21375,16 @@ hco:3q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q12.3#GRCh38
+hco:3q12.3\/GRCh38
 	rdf:type	hco:3q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21393,12 +21393,12 @@ hco:3q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21406,7 +21406,7 @@ hco:3q13.11
 	rdfs:label	"3q13.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.11#GRCh37
+hco:3q13.11\/GRCh37
 	rdf:type	hco:3q13.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21415,16 +21415,16 @@ hco:3q13.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.11#GRCh38
+hco:3q13.11\/GRCh38
 	rdf:type	hco:3q13.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21433,12 +21433,12 @@ hco:3q13.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21446,7 +21446,7 @@ hco:3q13.12
 	rdfs:label	"3q13.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.12#GRCh37
+hco:3q13.12\/GRCh37
 	rdf:type	hco:3q13.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21455,16 +21455,16 @@ hco:3q13.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.12#GRCh38
+hco:3q13.12\/GRCh38
 	rdf:type	hco:3q13.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21473,12 +21473,12 @@ hco:3q13.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21486,7 +21486,7 @@ hco:3q13.13
 	rdfs:label	"3q13.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.13#GRCh37
+hco:3q13.13\/GRCh37
 	rdf:type	hco:3q13.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -21495,16 +21495,16 @@ hco:3q13.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.13#GRCh38
+hco:3q13.13\/GRCh38
 	rdf:type	hco:3q13.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -21513,12 +21513,12 @@ hco:3q13.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21526,7 +21526,7 @@ hco:3q13.2
 	rdfs:label	"3q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.2#GRCh37
+hco:3q13.2\/GRCh37
 	rdf:type	hco:3q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21535,16 +21535,16 @@ hco:3q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.2#GRCh38
+hco:3q13.2\/GRCh38
 	rdf:type	hco:3q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21553,12 +21553,12 @@ hco:3q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113700000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21566,7 +21566,7 @@ hco:3q13.31
 	rdfs:label	"3q13.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.31#GRCh37
+hco:3q13.31\/GRCh37
 	rdf:type	hco:3q13.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21575,16 +21575,16 @@ hco:3q13.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.31#GRCh38
+hco:3q13.31\/GRCh38
 	rdf:type	hco:3q13.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21593,12 +21593,12 @@ hco:3q13.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113700000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21606,7 +21606,7 @@ hco:3q13.32
 	rdfs:label	"3q13.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.32#GRCh37
+hco:3q13.32\/GRCh37
 	rdf:type	hco:3q13.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21615,16 +21615,16 @@ hco:3q13.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.32#GRCh38
+hco:3q13.32\/GRCh38
 	rdf:type	hco:3q13.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21633,12 +21633,12 @@ hco:3q13.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21646,7 +21646,7 @@ hco:3q13.33
 	rdfs:label	"3q13.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q13.33#GRCh37
+hco:3q13.33\/GRCh37
 	rdf:type	hco:3q13.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21655,16 +21655,16 @@ hco:3q13.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q13.33#GRCh38
+hco:3q13.33\/GRCh38
 	rdf:type	hco:3q13.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -21673,12 +21673,12 @@ hco:3q13.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21686,7 +21686,7 @@ hco:3q21.1
 	rdfs:label	"3q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q21.1#GRCh37
+hco:3q21.1\/GRCh37
 	rdf:type	hco:3q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21695,16 +21695,16 @@ hco:3q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q21.1#GRCh38
+hco:3q21.1\/GRCh38
 	rdf:type	hco:3q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21713,12 +21713,12 @@ hco:3q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21726,7 +21726,7 @@ hco:3q21.2
 	rdfs:label	"3q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q21.2#GRCh37
+hco:3q21.2\/GRCh37
 	rdf:type	hco:3q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21735,16 +21735,16 @@ hco:3q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q21.2#GRCh38
+hco:3q21.2\/GRCh38
 	rdf:type	hco:3q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21753,12 +21753,12 @@ hco:3q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21766,7 +21766,7 @@ hco:3q21.3
 	rdfs:label	"3q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q21.3#GRCh37
+hco:3q21.3\/GRCh37
 	rdf:type	hco:3q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21775,16 +21775,16 @@ hco:3q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q21.3#GRCh38
+hco:3q21.3\/GRCh38
 	rdf:type	hco:3q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21793,12 +21793,12 @@ hco:3q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21806,7 +21806,7 @@ hco:3q22.1
 	rdfs:label	"3q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q22.1#GRCh37
+hco:3q22.1\/GRCh37
 	rdf:type	hco:3q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21815,16 +21815,16 @@ hco:3q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129200000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q22.1#GRCh38
+hco:3q22.1\/GRCh38
 	rdf:type	hco:3q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21833,12 +21833,12 @@ hco:3q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129500000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21846,7 +21846,7 @@ hco:3q22.2
 	rdfs:label	"3q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q22.2#GRCh37
+hco:3q22.2\/GRCh37
 	rdf:type	hco:3q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21855,16 +21855,16 @@ hco:3q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q22.2#GRCh38
+hco:3q22.2\/GRCh38
 	rdf:type	hco:3q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21873,12 +21873,12 @@ hco:3q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21886,7 +21886,7 @@ hco:3q22.3
 	rdfs:label	"3q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q22.3#GRCh37
+hco:3q22.3\/GRCh37
 	rdf:type	hco:3q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21895,16 +21895,16 @@ hco:3q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q22.3#GRCh38
+hco:3q22.3\/GRCh38
 	rdf:type	hco:3q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -21913,12 +21913,12 @@ hco:3q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21926,7 +21926,7 @@ hco:3q23
 	rdfs:label	"3q23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q23#GRCh37
+hco:3q23\/GRCh37
 	rdf:type	hco:3q23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -21935,16 +21935,16 @@ hco:3q23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q23#GRCh38
+hco:3q23\/GRCh38
 	rdf:type	hco:3q23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -21953,12 +21953,12 @@ hco:3q23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -21966,7 +21966,7 @@ hco:3q24
 	rdfs:label	"3q24" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q24#GRCh37
+hco:3q24\/GRCh37
 	rdf:type	hco:3q24 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -21975,16 +21975,16 @@ hco:3q24#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142800000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q24#GRCh38
+hco:3q24\/GRCh38
 	rdf:type	hco:3q24 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -21993,12 +21993,12 @@ hco:3q24#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143100000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22006,7 +22006,7 @@ hco:3q25.1
 	rdfs:label	"3q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q25.1#GRCh37
+hco:3q25.1\/GRCh37
 	rdf:type	hco:3q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22015,16 +22015,16 @@ hco:3q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q25.1#GRCh38
+hco:3q25.1\/GRCh38
 	rdf:type	hco:3q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22033,12 +22033,12 @@ hco:3q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22046,7 +22046,7 @@ hco:3q25.2
 	rdfs:label	"3q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q25.2#GRCh37
+hco:3q25.2\/GRCh37
 	rdf:type	hco:3q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22055,16 +22055,16 @@ hco:3q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152100000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q25.2#GRCh38
+hco:3q25.2\/GRCh38
 	rdf:type	hco:3q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22073,12 +22073,12 @@ hco:3q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22086,7 +22086,7 @@ hco:3q25.31
 	rdfs:label	"3q25.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q25.31#GRCh37
+hco:3q25.31\/GRCh37
 	rdf:type	hco:3q25.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22095,16 +22095,16 @@ hco:3q25.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	157000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q25.31#GRCh38
+hco:3q25.31\/GRCh38
 	rdf:type	hco:3q25.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22113,12 +22113,12 @@ hco:3q25.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	157300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22126,7 +22126,7 @@ hco:3q25.32
 	rdfs:label	"3q25.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q25.32#GRCh37
+hco:3q25.32\/GRCh37
 	rdf:type	hco:3q25.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22135,16 +22135,16 @@ hco:3q25.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	157000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q25.32#GRCh38
+hco:3q25.32\/GRCh38
 	rdf:type	hco:3q25.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22153,12 +22153,12 @@ hco:3q25.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	157300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22166,7 +22166,7 @@ hco:3q25.33
 	rdfs:label	"3q25.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q25.33#GRCh37
+hco:3q25.33\/GRCh37
 	rdf:type	hco:3q25.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22175,16 +22175,16 @@ hco:3q25.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q25.33#GRCh38
+hco:3q25.33\/GRCh38
 	rdf:type	hco:3q25.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22193,12 +22193,12 @@ hco:3q25.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22206,7 +22206,7 @@ hco:3q26.1
 	rdfs:label	"3q26.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q26.1#GRCh37
+hco:3q26.1\/GRCh37
 	rdf:type	hco:3q26.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -22215,16 +22215,16 @@ hco:3q26.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q26.1#GRCh38
+hco:3q26.1\/GRCh38
 	rdf:type	hco:3q26.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -22233,12 +22233,12 @@ hco:3q26.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167900000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22246,7 +22246,7 @@ hco:3q26.2
 	rdfs:label	"3q26.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q26.2#GRCh37
+hco:3q26.2\/GRCh37
 	rdf:type	hco:3q26.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22255,16 +22255,16 @@ hco:3q26.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167600000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q26.2#GRCh38
+hco:3q26.2\/GRCh38
 	rdf:type	hco:3q26.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22273,12 +22273,12 @@ hco:3q26.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	167900000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22286,7 +22286,7 @@ hco:3q26.31
 	rdfs:label	"3q26.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q26.31#GRCh37
+hco:3q26.31\/GRCh37
 	rdf:type	hco:3q26.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22295,16 +22295,16 @@ hco:3q26.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	175700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q26.31#GRCh38
+hco:3q26.31\/GRCh38
 	rdf:type	hco:3q26.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22313,12 +22313,12 @@ hco:3q26.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22326,7 +22326,7 @@ hco:3q26.32
 	rdfs:label	"3q26.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q26.32#GRCh37
+hco:3q26.32\/GRCh37
 	rdf:type	hco:3q26.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22335,16 +22335,16 @@ hco:3q26.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	175700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q26.32#GRCh38
+hco:3q26.32\/GRCh38
 	rdf:type	hco:3q26.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22353,12 +22353,12 @@ hco:3q26.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22366,7 +22366,7 @@ hco:3q26.33
 	rdfs:label	"3q26.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q26.33#GRCh37
+hco:3q26.33\/GRCh37
 	rdf:type	hco:3q26.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22375,16 +22375,16 @@ hco:3q26.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q26.33#GRCh38
+hco:3q26.33\/GRCh38
 	rdf:type	hco:3q26.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22393,12 +22393,12 @@ hco:3q26.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	179300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22406,7 +22406,7 @@ hco:3q27.1
 	rdfs:label	"3q27.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q27.1#GRCh37
+hco:3q27.1\/GRCh37
 	rdf:type	hco:3q27.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22415,16 +22415,16 @@ hco:3q27.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182700000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	184500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q27.1#GRCh38
+hco:3q27.1\/GRCh38
 	rdf:type	hco:3q27.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22433,12 +22433,12 @@ hco:3q27.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183000000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	184800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22446,7 +22446,7 @@ hco:3q27.2
 	rdfs:label	"3q27.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q27.2#GRCh37
+hco:3q27.2\/GRCh37
 	rdf:type	hco:3q27.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -22455,16 +22455,16 @@ hco:3q27.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	184500000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q27.2#GRCh38
+hco:3q27.2\/GRCh38
 	rdf:type	hco:3q27.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -22473,12 +22473,12 @@ hco:3q27.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	184800000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22486,7 +22486,7 @@ hco:3q27.3
 	rdfs:label	"3q27.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q27.3#GRCh37
+hco:3q27.3\/GRCh37
 	rdf:type	hco:3q27.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22495,16 +22495,16 @@ hco:3q27.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186000000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	187900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q27.3#GRCh38
+hco:3q27.3\/GRCh38
 	rdf:type	hco:3q27.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22513,12 +22513,12 @@ hco:3q27.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186300000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	188200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22526,7 +22526,7 @@ hco:3q28
 	rdfs:label	"3q28" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q28#GRCh37
+hco:3q28\/GRCh37
 	rdf:type	hco:3q28 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22535,16 +22535,16 @@ hco:3q28#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	187900000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	192300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q28#GRCh38
+hco:3q28\/GRCh38
 	rdf:type	hco:3q28 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22553,12 +22553,12 @@ hco:3q28#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	188200000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	192600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22566,7 +22566,7 @@ hco:3q29
 	rdfs:label	"3q29" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:3q29#GRCh37
+hco:3q29\/GRCh37
 	rdf:type	hco:3q29 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22575,16 +22575,16 @@ hco:3q29#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	192300000 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198022430 ;
-			faldo:reference	hco:3#GRCh37
+			faldo:reference	hco:3\/GRCh37
 		]
 	] .
 
-hco:3q29#GRCh38
+hco:3q29\/GRCh38
 	rdf:type	hco:3q29 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22593,12 +22593,12 @@ hco:3q29#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	192600000 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	198295559 ;
-			faldo:reference	hco:3#GRCh38
+			faldo:reference	hco:3\/GRCh38
 		]
 	] .
 
@@ -22606,7 +22606,7 @@ hco:4p16.3
 	rdfs:label	"4p16.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p16.3#GRCh37
+hco:4p16.3\/GRCh37
 	rdf:type	hco:4p16.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22615,16 +22615,16 @@ hco:4p16.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p16.3#GRCh38
+hco:4p16.3\/GRCh38
 	rdf:type	hco:4p16.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22633,12 +22633,12 @@ hco:4p16.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22646,7 +22646,7 @@ hco:4p16.2
 	rdfs:label	"4p16.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p16.2#GRCh37
+hco:4p16.2\/GRCh37
 	rdf:type	hco:4p16.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -22655,16 +22655,16 @@ hco:4p16.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p16.2#GRCh38
+hco:4p16.2\/GRCh38
 	rdf:type	hco:4p16.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -22673,12 +22673,12 @@ hco:4p16.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22686,7 +22686,7 @@ hco:4p16.1
 	rdfs:label	"4p16.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p16.1#GRCh37
+hco:4p16.1\/GRCh37
 	rdf:type	hco:4p16.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22695,16 +22695,16 @@ hco:4p16.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p16.1#GRCh38
+hco:4p16.1\/GRCh38
 	rdf:type	hco:4p16.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22713,12 +22713,12 @@ hco:4p16.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22726,7 +22726,7 @@ hco:4p15.33
 	rdfs:label	"4p15.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p15.33#GRCh37
+hco:4p15.33\/GRCh37
 	rdf:type	hco:4p15.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22735,16 +22735,16 @@ hco:4p15.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p15.33#GRCh38
+hco:4p15.33\/GRCh38
 	rdf:type	hco:4p15.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22753,12 +22753,12 @@ hco:4p15.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22766,7 +22766,7 @@ hco:4p15.32
 	rdfs:label	"4p15.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p15.32#GRCh37
+hco:4p15.32\/GRCh37
 	rdf:type	hco:4p15.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22775,16 +22775,16 @@ hco:4p15.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p15.32#GRCh38
+hco:4p15.32\/GRCh38
 	rdf:type	hco:4p15.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22793,12 +22793,12 @@ hco:4p15.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22806,7 +22806,7 @@ hco:4p15.31
 	rdfs:label	"4p15.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p15.31#GRCh37
+hco:4p15.31\/GRCh37
 	rdf:type	hco:4p15.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22815,16 +22815,16 @@ hco:4p15.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p15.31#GRCh38
+hco:4p15.31\/GRCh38
 	rdf:type	hco:4p15.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -22833,12 +22833,12 @@ hco:4p15.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22846,7 +22846,7 @@ hco:4p15.2
 	rdfs:label	"4p15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p15.2#GRCh37
+hco:4p15.2\/GRCh37
 	rdf:type	hco:4p15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22855,16 +22855,16 @@ hco:4p15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p15.2#GRCh38
+hco:4p15.2\/GRCh38
 	rdf:type	hco:4p15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22873,12 +22873,12 @@ hco:4p15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22886,7 +22886,7 @@ hco:4p15.1
 	rdfs:label	"4p15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p15.1#GRCh37
+hco:4p15.1\/GRCh37
 	rdf:type	hco:4p15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -22895,16 +22895,16 @@ hco:4p15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p15.1#GRCh38
+hco:4p15.1\/GRCh38
 	rdf:type	hco:4p15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -22913,12 +22913,12 @@ hco:4p15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22926,7 +22926,7 @@ hco:4p14
 	rdfs:label	"4p14" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p14#GRCh37
+hco:4p14\/GRCh37
 	rdf:type	hco:4p14 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -22935,16 +22935,16 @@ hco:4p14#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p14#GRCh38
+hco:4p14\/GRCh38
 	rdf:type	hco:4p14 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -22953,12 +22953,12 @@ hco:4p14#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -22966,7 +22966,7 @@ hco:4p13
 	rdfs:label	"4p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p13#GRCh37
+hco:4p13\/GRCh37
 	rdf:type	hco:4p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22975,16 +22975,16 @@ hco:4p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p13#GRCh38
+hco:4p13\/GRCh38
 	rdf:type	hco:4p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -22993,12 +22993,12 @@ hco:4p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23006,7 +23006,7 @@ hco:4p12
 	rdfs:label	"4p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p12#GRCh37
+hco:4p12\/GRCh37
 	rdf:type	hco:4p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23015,16 +23015,16 @@ hco:4p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p12#GRCh38
+hco:4p12\/GRCh38
 	rdf:type	hco:4p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23033,12 +23033,12 @@ hco:4p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	44600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23046,7 +23046,7 @@ hco:4p11
 	rdfs:label	"4p11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4p11#GRCh37
+hco:4p11\/GRCh37
 	rdf:type	hco:4p11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -23055,16 +23055,16 @@ hco:4p11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50400000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4p11#GRCh38
+hco:4p11\/GRCh38
 	rdf:type	hco:4p11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -23073,12 +23073,12 @@ hco:4p11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23086,7 +23086,7 @@ hco:4q11
 	rdfs:label	"4q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q11#GRCh37
+hco:4q11\/GRCh37
 	rdf:type	hco:4q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -23095,16 +23095,16 @@ hco:4q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50400000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q11#GRCh38
+hco:4q11\/GRCh38
 	rdf:type	hco:4q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -23113,12 +23113,12 @@ hco:4q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23126,7 +23126,7 @@ hco:4q12
 	rdfs:label	"4q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q12#GRCh37
+hco:4q12\/GRCh37
 	rdf:type	hco:4q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23135,16 +23135,16 @@ hco:4q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q12#GRCh38
+hco:4q12\/GRCh38
 	rdf:type	hco:4q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23153,12 +23153,12 @@ hco:4q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23166,7 +23166,7 @@ hco:4q13.1
 	rdfs:label	"4q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q13.1#GRCh37
+hco:4q13.1\/GRCh37
 	rdf:type	hco:4q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -23175,16 +23175,16 @@ hco:4q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q13.1#GRCh38
+hco:4q13.1\/GRCh38
 	rdf:type	hco:4q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -23193,12 +23193,12 @@ hco:4q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23206,7 +23206,7 @@ hco:4q13.2
 	rdfs:label	"4q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q13.2#GRCh37
+hco:4q13.2\/GRCh37
 	rdf:type	hco:4q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23215,16 +23215,16 @@ hco:4q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q13.2#GRCh38
+hco:4q13.2\/GRCh38
 	rdf:type	hco:4q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23233,12 +23233,12 @@ hco:4q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69400000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23246,7 +23246,7 @@ hco:4q13.3
 	rdfs:label	"4q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q13.3#GRCh37
+hco:4q13.3\/GRCh37
 	rdf:type	hco:4q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23255,16 +23255,16 @@ hco:4q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q13.3#GRCh38
+hco:4q13.3\/GRCh38
 	rdf:type	hco:4q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23273,12 +23273,12 @@ hco:4q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69400000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23286,7 +23286,7 @@ hco:4q21.1
 	rdfs:label	"4q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q21.1#GRCh37
+hco:4q21.1\/GRCh37
 	rdf:type	hco:4q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23295,16 +23295,16 @@ hco:4q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q21.1#GRCh38
+hco:4q21.1\/GRCh38
 	rdf:type	hco:4q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23313,12 +23313,12 @@ hco:4q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23326,7 +23326,7 @@ hco:4q21.21
 	rdfs:label	"4q21.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q21.21#GRCh37
+hco:4q21.21\/GRCh37
 	rdf:type	hco:4q21.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23335,16 +23335,16 @@ hco:4q21.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82400000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q21.21#GRCh38
+hco:4q21.21\/GRCh38
 	rdf:type	hco:4q21.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23353,12 +23353,12 @@ hco:4q21.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23366,7 +23366,7 @@ hco:4q21.22
 	rdfs:label	"4q21.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q21.22#GRCh37
+hco:4q21.22\/GRCh37
 	rdf:type	hco:4q21.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23375,16 +23375,16 @@ hco:4q21.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82400000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q21.22#GRCh38
+hco:4q21.22\/GRCh38
 	rdf:type	hco:4q21.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23393,12 +23393,12 @@ hco:4q21.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23406,7 +23406,7 @@ hco:4q21.23
 	rdfs:label	"4q21.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q21.23#GRCh37
+hco:4q21.23\/GRCh37
 	rdf:type	hco:4q21.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -23415,16 +23415,16 @@ hco:4q21.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q21.23#GRCh38
+hco:4q21.23\/GRCh38
 	rdf:type	hco:4q21.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -23433,12 +23433,12 @@ hco:4q21.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23446,7 +23446,7 @@ hco:4q21.3
 	rdfs:label	"4q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q21.3#GRCh37
+hco:4q21.3\/GRCh37
 	rdf:type	hco:4q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23455,16 +23455,16 @@ hco:4q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88000000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q21.3#GRCh38
+hco:4q21.3\/GRCh38
 	rdf:type	hco:4q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23473,12 +23473,12 @@ hco:4q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23486,7 +23486,7 @@ hco:4q22.1
 	rdfs:label	"4q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q22.1#GRCh37
+hco:4q22.1\/GRCh37
 	rdf:type	hco:4q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23495,16 +23495,16 @@ hco:4q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88000000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q22.1#GRCh38
+hco:4q22.1\/GRCh38
 	rdf:type	hco:4q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23513,12 +23513,12 @@ hco:4q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23526,7 +23526,7 @@ hco:4q22.2
 	rdfs:label	"4q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q22.2#GRCh37
+hco:4q22.2\/GRCh37
 	rdf:type	hco:4q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23535,16 +23535,16 @@ hco:4q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q22.2#GRCh38
+hco:4q22.2\/GRCh38
 	rdf:type	hco:4q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23553,12 +23553,12 @@ hco:4q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23566,7 +23566,7 @@ hco:4q22.3
 	rdfs:label	"4q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q22.3#GRCh37
+hco:4q22.3\/GRCh37
 	rdf:type	hco:4q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23575,16 +23575,16 @@ hco:4q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	95100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q22.3#GRCh38
+hco:4q22.3\/GRCh38
 	rdf:type	hco:4q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23593,12 +23593,12 @@ hco:4q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23606,7 +23606,7 @@ hco:4q23
 	rdfs:label	"4q23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q23#GRCh37
+hco:4q23\/GRCh37
 	rdf:type	hco:4q23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23615,16 +23615,16 @@ hco:4q23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q23#GRCh38
+hco:4q23\/GRCh38
 	rdf:type	hco:4q23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23633,12 +23633,12 @@ hco:4q23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23646,7 +23646,7 @@ hco:4q24
 	rdfs:label	"4q24" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q24#GRCh37
+hco:4q24\/GRCh37
 	rdf:type	hco:4q24 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23655,16 +23655,16 @@ hco:4q24#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q24#GRCh38
+hco:4q24\/GRCh38
 	rdf:type	hco:4q24 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23673,12 +23673,12 @@ hco:4q24#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23686,7 +23686,7 @@ hco:4q25
 	rdfs:label	"4q25" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q25#GRCh37
+hco:4q25\/GRCh37
 	rdf:type	hco:4q25 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23695,16 +23695,16 @@ hco:4q25#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107700000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q25#GRCh38
+hco:4q25\/GRCh38
 	rdf:type	hco:4q25 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23713,12 +23713,12 @@ hco:4q25#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106700000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23726,7 +23726,7 @@ hco:4q26
 	rdfs:label	"4q26" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q26#GRCh37
+hco:4q26\/GRCh37
 	rdf:type	hco:4q26 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23735,16 +23735,16 @@ hco:4q26#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q26#GRCh38
+hco:4q26\/GRCh38
 	rdf:type	hco:4q26 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -23753,12 +23753,12 @@ hco:4q26#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23766,7 +23766,7 @@ hco:4q27
 	rdfs:label	"4q27" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q27#GRCh37
+hco:4q27\/GRCh37
 	rdf:type	hco:4q27 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23775,16 +23775,16 @@ hco:4q27#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q27#GRCh38
+hco:4q27\/GRCh38
 	rdf:type	hco:4q27 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23793,12 +23793,12 @@ hco:4q27#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23806,7 +23806,7 @@ hco:4q28.1
 	rdfs:label	"4q28.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q28.1#GRCh37
+hco:4q28.1\/GRCh37
 	rdf:type	hco:4q28.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23815,16 +23815,16 @@ hco:4q28.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q28.1#GRCh38
+hco:4q28.1\/GRCh38
 	rdf:type	hco:4q28.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -23833,12 +23833,12 @@ hco:4q28.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23846,7 +23846,7 @@ hco:4q28.2
 	rdfs:label	"4q28.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q28.2#GRCh37
+hco:4q28.2\/GRCh37
 	rdf:type	hco:4q28.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23855,16 +23855,16 @@ hco:4q28.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q28.2#GRCh38
+hco:4q28.2\/GRCh38
 	rdf:type	hco:4q28.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23873,12 +23873,12 @@ hco:4q28.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23886,7 +23886,7 @@ hco:4q28.3
 	rdfs:label	"4q28.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q28.3#GRCh37
+hco:4q28.3\/GRCh37
 	rdf:type	hco:4q28.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -23895,16 +23895,16 @@ hco:4q28.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q28.3#GRCh38
+hco:4q28.3\/GRCh38
 	rdf:type	hco:4q28.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -23913,12 +23913,12 @@ hco:4q28.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130100000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23926,7 +23926,7 @@ hco:4q31.1
 	rdfs:label	"4q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q31.1#GRCh37
+hco:4q31.1\/GRCh37
 	rdf:type	hco:4q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -23935,16 +23935,16 @@ hco:4q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q31.1#GRCh38
+hco:4q31.1\/GRCh38
 	rdf:type	hco:4q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -23953,12 +23953,12 @@ hco:4q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -23966,7 +23966,7 @@ hco:4q31.21
 	rdfs:label	"4q31.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q31.21#GRCh37
+hco:4q31.21\/GRCh37
 	rdf:type	hco:4q31.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -23975,16 +23975,16 @@ hco:4q31.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	146800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q31.21#GRCh38
+hco:4q31.21\/GRCh38
 	rdf:type	hco:4q31.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -23993,12 +23993,12 @@ hco:4q31.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24006,7 +24006,7 @@ hco:4q31.22
 	rdfs:label	"4q31.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q31.22#GRCh37
+hco:4q31.22\/GRCh37
 	rdf:type	hco:4q31.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24015,16 +24015,16 @@ hco:4q31.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	146800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q31.22#GRCh38
+hco:4q31.22\/GRCh38
 	rdf:type	hco:4q31.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24033,12 +24033,12 @@ hco:4q31.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145900000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24046,7 +24046,7 @@ hco:4q31.23
 	rdfs:label	"4q31.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q31.23#GRCh37
+hco:4q31.23\/GRCh37
 	rdf:type	hco:4q31.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24055,16 +24055,16 @@ hco:4q31.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	151100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q31.23#GRCh38
+hco:4q31.23\/GRCh38
 	rdf:type	hco:4q31.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24073,12 +24073,12 @@ hco:4q31.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147500000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24086,7 +24086,7 @@ hco:4q31.3
 	rdfs:label	"4q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q31.3#GRCh37
+hco:4q31.3\/GRCh37
 	rdf:type	hco:4q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24095,16 +24095,16 @@ hco:4q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	151100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q31.3#GRCh38
+hco:4q31.3\/GRCh38
 	rdf:type	hco:4q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24113,12 +24113,12 @@ hco:4q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24126,7 +24126,7 @@ hco:4q32.1
 	rdfs:label	"4q32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q32.1#GRCh37
+hco:4q32.1\/GRCh37
 	rdf:type	hco:4q32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24135,16 +24135,16 @@ hco:4q32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155600000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q32.1#GRCh38
+hco:4q32.1\/GRCh38
 	rdf:type	hco:4q32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24153,12 +24153,12 @@ hco:4q32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	154600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24166,7 +24166,7 @@ hco:4q32.2
 	rdfs:label	"4q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q32.2#GRCh37
+hco:4q32.2\/GRCh37
 	rdf:type	hco:4q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24175,16 +24175,16 @@ hco:4q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161800000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q32.2#GRCh38
+hco:4q32.2\/GRCh38
 	rdf:type	hco:4q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24193,12 +24193,12 @@ hco:4q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160800000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	163600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24206,7 +24206,7 @@ hco:4q32.3
 	rdfs:label	"4q32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q32.3#GRCh37
+hco:4q32.3\/GRCh37
 	rdf:type	hco:4q32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24215,16 +24215,16 @@ hco:4q32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q32.3#GRCh38
+hco:4q32.3\/GRCh38
 	rdf:type	hco:4q32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24233,12 +24233,12 @@ hco:4q32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	163600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24246,7 +24246,7 @@ hco:4q33
 	rdfs:label	"4q33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q33#GRCh37
+hco:4q33\/GRCh37
 	rdf:type	hco:4q33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24255,16 +24255,16 @@ hco:4q33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q33#GRCh38
+hco:4q33\/GRCh38
 	rdf:type	hco:4q33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24273,12 +24273,12 @@ hco:4q33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24286,7 +24286,7 @@ hco:4q34.1
 	rdfs:label	"4q34.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q34.1#GRCh37
+hco:4q34.1\/GRCh37
 	rdf:type	hco:4q34.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -24295,16 +24295,16 @@ hco:4q34.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171900000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q34.1#GRCh38
+hco:4q34.1\/GRCh38
 	rdf:type	hco:4q34.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -24313,12 +24313,12 @@ hco:4q34.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171000000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	175400000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24326,7 +24326,7 @@ hco:4q34.2
 	rdfs:label	"4q34.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q34.2#GRCh37
+hco:4q34.2\/GRCh37
 	rdf:type	hco:4q34.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24335,16 +24335,16 @@ hco:4q34.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176300000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q34.2#GRCh38
+hco:4q34.2\/GRCh38
 	rdf:type	hco:4q34.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24353,12 +24353,12 @@ hco:4q34.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	175400000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24366,7 +24366,7 @@ hco:4q34.3
 	rdfs:label	"4q34.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q34.3#GRCh37
+hco:4q34.3\/GRCh37
 	rdf:type	hco:4q34.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24375,16 +24375,16 @@ hco:4q34.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177500000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q34.3#GRCh38
+hco:4q34.3\/GRCh38
 	rdf:type	hco:4q34.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24393,12 +24393,12 @@ hco:4q34.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176600000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24406,7 +24406,7 @@ hco:4q35.1
 	rdfs:label	"4q35.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q35.1#GRCh37
+hco:4q35.1\/GRCh37
 	rdf:type	hco:4q35.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24415,16 +24415,16 @@ hco:4q35.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	183200000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	187100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q35.1#GRCh38
+hco:4q35.1\/GRCh38
 	rdf:type	hco:4q35.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24433,12 +24433,12 @@ hco:4q35.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	182300000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24446,7 +24446,7 @@ hco:4q35.2
 	rdfs:label	"4q35.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:4q35.2#GRCh37
+hco:4q35.2\/GRCh37
 	rdf:type	hco:4q35.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24455,16 +24455,16 @@ hco:4q35.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	187100000 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	191154276 ;
-			faldo:reference	hco:4#GRCh37
+			faldo:reference	hco:4\/GRCh37
 		]
 	] .
 
-hco:4q35.2#GRCh38
+hco:4q35.2\/GRCh38
 	rdf:type	hco:4q35.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24473,12 +24473,12 @@ hco:4q35.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	186200000 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	190214555 ;
-			faldo:reference	hco:4#GRCh38
+			faldo:reference	hco:4\/GRCh38
 		]
 	] .
 
@@ -24486,7 +24486,7 @@ hco:5p15.33
 	rdfs:label	"5p15.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p15.33#GRCh37
+hco:5p15.33\/GRCh37
 	rdf:type	hco:5p15.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24495,16 +24495,16 @@ hco:5p15.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p15.33#GRCh38
+hco:5p15.33\/GRCh38
 	rdf:type	hco:5p15.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24513,12 +24513,12 @@ hco:5p15.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24526,7 +24526,7 @@ hco:5p15.32
 	rdfs:label	"5p15.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p15.32#GRCh37
+hco:5p15.32\/GRCh37
 	rdf:type	hco:5p15.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24535,16 +24535,16 @@ hco:5p15.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p15.32#GRCh38
+hco:5p15.32\/GRCh38
 	rdf:type	hco:5p15.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24553,12 +24553,12 @@ hco:5p15.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24566,7 +24566,7 @@ hco:5p15.31
 	rdfs:label	"5p15.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p15.31#GRCh37
+hco:5p15.31\/GRCh37
 	rdf:type	hco:5p15.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24575,16 +24575,16 @@ hco:5p15.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p15.31#GRCh38
+hco:5p15.31\/GRCh38
 	rdf:type	hco:5p15.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24593,12 +24593,12 @@ hco:5p15.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24606,7 +24606,7 @@ hco:5p15.2
 	rdfs:label	"5p15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p15.2#GRCh37
+hco:5p15.2\/GRCh37
 	rdf:type	hco:5p15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -24615,16 +24615,16 @@ hco:5p15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p15.2#GRCh38
+hco:5p15.2\/GRCh38
 	rdf:type	hco:5p15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -24633,12 +24633,12 @@ hco:5p15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24646,7 +24646,7 @@ hco:5p15.1
 	rdfs:label	"5p15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p15.1#GRCh37
+hco:5p15.1\/GRCh37
 	rdf:type	hco:5p15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24655,16 +24655,16 @@ hco:5p15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p15.1#GRCh38
+hco:5p15.1\/GRCh38
 	rdf:type	hco:5p15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24673,12 +24673,12 @@ hco:5p15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24686,7 +24686,7 @@ hco:5p14.3
 	rdfs:label	"5p14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p14.3#GRCh37
+hco:5p14.3\/GRCh37
 	rdf:type	hco:5p14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24695,16 +24695,16 @@ hco:5p14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p14.3#GRCh38
+hco:5p14.3\/GRCh38
 	rdf:type	hco:5p14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24713,12 +24713,12 @@ hco:5p14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24726,7 +24726,7 @@ hco:5p14.2
 	rdfs:label	"5p14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p14.2#GRCh37
+hco:5p14.2\/GRCh37
 	rdf:type	hco:5p14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24735,16 +24735,16 @@ hco:5p14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p14.2#GRCh38
+hco:5p14.2\/GRCh38
 	rdf:type	hco:5p14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24753,12 +24753,12 @@ hco:5p14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24766,7 +24766,7 @@ hco:5p14.1
 	rdfs:label	"5p14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p14.1#GRCh37
+hco:5p14.1\/GRCh37
 	rdf:type	hco:5p14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24775,16 +24775,16 @@ hco:5p14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p14.1#GRCh38
+hco:5p14.1\/GRCh38
 	rdf:type	hco:5p14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -24793,12 +24793,12 @@ hco:5p14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24806,7 +24806,7 @@ hco:5p13.3
 	rdfs:label	"5p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p13.3#GRCh37
+hco:5p13.3\/GRCh37
 	rdf:type	hco:5p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24815,16 +24815,16 @@ hco:5p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p13.3#GRCh38
+hco:5p13.3\/GRCh38
 	rdf:type	hco:5p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24833,12 +24833,12 @@ hco:5p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24846,7 +24846,7 @@ hco:5p13.2
 	rdfs:label	"5p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p13.2#GRCh37
+hco:5p13.2\/GRCh37
 	rdf:type	hco:5p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24855,16 +24855,16 @@ hco:5p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p13.2#GRCh38
+hco:5p13.2\/GRCh38
 	rdf:type	hco:5p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -24873,12 +24873,12 @@ hco:5p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24886,7 +24886,7 @@ hco:5p13.1
 	rdfs:label	"5p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p13.1#GRCh37
+hco:5p13.1\/GRCh37
 	rdf:type	hco:5p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -24895,16 +24895,16 @@ hco:5p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p13.1#GRCh38
+hco:5p13.1\/GRCh38
 	rdf:type	hco:5p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -24913,12 +24913,12 @@ hco:5p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24926,7 +24926,7 @@ hco:5p12
 	rdfs:label	"5p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p12#GRCh37
+hco:5p12\/GRCh37
 	rdf:type	hco:5p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -24935,16 +24935,16 @@ hco:5p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p12#GRCh38
+hco:5p12\/GRCh38
 	rdf:type	hco:5p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -24953,12 +24953,12 @@ hco:5p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -24966,7 +24966,7 @@ hco:5p11
 	rdfs:label	"5p11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5p11#GRCh37
+hco:5p11\/GRCh37
 	rdf:type	hco:5p11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -24975,16 +24975,16 @@ hco:5p11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5p11#GRCh38
+hco:5p11\/GRCh38
 	rdf:type	hco:5p11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -24993,12 +24993,12 @@ hco:5p11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25006,7 +25006,7 @@ hco:5q11.1
 	rdfs:label	"5q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q11.1#GRCh37
+hco:5q11.1\/GRCh37
 	rdf:type	hco:5q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -25015,16 +25015,16 @@ hco:5q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q11.1#GRCh38
+hco:5q11.1\/GRCh38
 	rdf:type	hco:5q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -25033,12 +25033,12 @@ hco:5q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25046,7 +25046,7 @@ hco:5q11.2
 	rdfs:label	"5q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q11.2#GRCh37
+hco:5q11.2\/GRCh37
 	rdf:type	hco:5q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25055,16 +25055,16 @@ hco:5q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q11.2#GRCh38
+hco:5q11.2\/GRCh38
 	rdf:type	hco:5q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25073,12 +25073,12 @@ hco:5q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25086,7 +25086,7 @@ hco:5q12.1
 	rdfs:label	"5q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q12.1#GRCh37
+hco:5q12.1\/GRCh37
 	rdf:type	hco:5q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25095,16 +25095,16 @@ hco:5q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q12.1#GRCh38
+hco:5q12.1\/GRCh38
 	rdf:type	hco:5q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25113,12 +25113,12 @@ hco:5q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25126,7 +25126,7 @@ hco:5q12.2
 	rdfs:label	"5q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q12.2#GRCh37
+hco:5q12.2\/GRCh37
 	rdf:type	hco:5q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25135,16 +25135,16 @@ hco:5q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q12.2#GRCh38
+hco:5q12.2\/GRCh38
 	rdf:type	hco:5q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25153,12 +25153,12 @@ hco:5q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25166,7 +25166,7 @@ hco:5q12.3
 	rdfs:label	"5q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q12.3#GRCh37
+hco:5q12.3\/GRCh37
 	rdf:type	hco:5q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25175,16 +25175,16 @@ hco:5q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q12.3#GRCh38
+hco:5q12.3\/GRCh38
 	rdf:type	hco:5q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25193,12 +25193,12 @@ hco:5q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25206,7 +25206,7 @@ hco:5q13.1
 	rdfs:label	"5q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q13.1#GRCh37
+hco:5q13.1\/GRCh37
 	rdf:type	hco:5q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25215,16 +25215,16 @@ hco:5q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q13.1#GRCh38
+hco:5q13.1\/GRCh38
 	rdf:type	hco:5q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25233,12 +25233,12 @@ hco:5q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25246,7 +25246,7 @@ hco:5q13.2
 	rdfs:label	"5q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q13.2#GRCh37
+hco:5q13.2\/GRCh37
 	rdf:type	hco:5q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25255,16 +25255,16 @@ hco:5q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q13.2#GRCh38
+hco:5q13.2\/GRCh38
 	rdf:type	hco:5q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25273,12 +25273,12 @@ hco:5q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25286,7 +25286,7 @@ hco:5q13.3
 	rdfs:label	"5q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q13.3#GRCh37
+hco:5q13.3\/GRCh37
 	rdf:type	hco:5q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25295,16 +25295,16 @@ hco:5q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q13.3#GRCh38
+hco:5q13.3\/GRCh38
 	rdf:type	hco:5q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25313,12 +25313,12 @@ hco:5q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25326,7 +25326,7 @@ hco:5q14.1
 	rdfs:label	"5q14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q14.1#GRCh37
+hco:5q14.1\/GRCh37
 	rdf:type	hco:5q14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25335,16 +25335,16 @@ hco:5q14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q14.1#GRCh38
+hco:5q14.1\/GRCh38
 	rdf:type	hco:5q14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25353,12 +25353,12 @@ hco:5q14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77600000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25366,7 +25366,7 @@ hco:5q14.2
 	rdfs:label	"5q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q14.2#GRCh37
+hco:5q14.2\/GRCh37
 	rdf:type	hco:5q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25375,16 +25375,16 @@ hco:5q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q14.2#GRCh38
+hco:5q14.2\/GRCh38
 	rdf:type	hco:5q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25393,12 +25393,12 @@ hco:5q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25406,7 +25406,7 @@ hco:5q14.3
 	rdfs:label	"5q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q14.3#GRCh37
+hco:5q14.3\/GRCh37
 	rdf:type	hco:5q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25415,16 +25415,16 @@ hco:5q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	82800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q14.3#GRCh38
+hco:5q14.3\/GRCh38
 	rdf:type	hco:5q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25433,12 +25433,12 @@ hco:5q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25446,7 +25446,7 @@ hco:5q15
 	rdfs:label	"5q15" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q15#GRCh37
+hco:5q15\/GRCh37
 	rdf:type	hco:5q15 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25455,16 +25455,16 @@ hco:5q15#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q15#GRCh38
+hco:5q15\/GRCh38
 	rdf:type	hco:5q15 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25473,12 +25473,12 @@ hco:5q15#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25486,7 +25486,7 @@ hco:5q21.1
 	rdfs:label	"5q21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q21.1#GRCh37
+hco:5q21.1\/GRCh37
 	rdf:type	hco:5q21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25495,16 +25495,16 @@ hco:5q21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q21.1#GRCh38
+hco:5q21.1\/GRCh38
 	rdf:type	hco:5q21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25513,12 +25513,12 @@ hco:5q21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25526,7 +25526,7 @@ hco:5q21.2
 	rdfs:label	"5q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q21.2#GRCh37
+hco:5q21.2\/GRCh37
 	rdf:type	hco:5q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25535,16 +25535,16 @@ hco:5q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q21.2#GRCh38
+hco:5q21.2\/GRCh38
 	rdf:type	hco:5q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25553,12 +25553,12 @@ hco:5q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25566,7 +25566,7 @@ hco:5q21.3
 	rdfs:label	"5q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q21.3#GRCh37
+hco:5q21.3\/GRCh37
 	rdf:type	hco:5q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25575,16 +25575,16 @@ hco:5q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q21.3#GRCh38
+hco:5q21.3\/GRCh38
 	rdf:type	hco:5q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25593,12 +25593,12 @@ hco:5q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25606,7 +25606,7 @@ hco:5q22.1
 	rdfs:label	"5q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q22.1#GRCh37
+hco:5q22.1\/GRCh37
 	rdf:type	hco:5q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25615,16 +25615,16 @@ hco:5q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q22.1#GRCh38
+hco:5q22.1\/GRCh38
 	rdf:type	hco:5q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25633,12 +25633,12 @@ hco:5q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25646,7 +25646,7 @@ hco:5q22.2
 	rdfs:label	"5q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q22.2#GRCh37
+hco:5q22.2\/GRCh37
 	rdf:type	hco:5q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25655,16 +25655,16 @@ hco:5q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113100000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q22.2#GRCh38
+hco:5q22.2\/GRCh38
 	rdf:type	hco:5q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -25673,12 +25673,12 @@ hco:5q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25686,7 +25686,7 @@ hco:5q22.3
 	rdfs:label	"5q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q22.3#GRCh37
+hco:5q22.3\/GRCh37
 	rdf:type	hco:5q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25695,16 +25695,16 @@ hco:5q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113100000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q22.3#GRCh38
+hco:5q22.3\/GRCh38
 	rdf:type	hco:5q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25713,12 +25713,12 @@ hco:5q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	113800000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25726,7 +25726,7 @@ hco:5q23.1
 	rdfs:label	"5q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q23.1#GRCh37
+hco:5q23.1\/GRCh37
 	rdf:type	hco:5q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25735,16 +25735,16 @@ hco:5q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q23.1#GRCh38
+hco:5q23.1\/GRCh38
 	rdf:type	hco:5q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25753,12 +25753,12 @@ hco:5q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25766,7 +25766,7 @@ hco:5q23.2
 	rdfs:label	"5q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q23.2#GRCh37
+hco:5q23.2\/GRCh37
 	rdf:type	hco:5q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25775,16 +25775,16 @@ hco:5q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q23.2#GRCh38
+hco:5q23.2\/GRCh38
 	rdf:type	hco:5q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25793,12 +25793,12 @@ hco:5q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25806,7 +25806,7 @@ hco:5q23.3
 	rdfs:label	"5q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q23.3#GRCh37
+hco:5q23.3\/GRCh37
 	rdf:type	hco:5q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25815,16 +25815,16 @@ hco:5q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127300000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q23.3#GRCh38
+hco:5q23.3\/GRCh38
 	rdf:type	hco:5q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -25833,12 +25833,12 @@ hco:5q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25846,7 +25846,7 @@ hco:5q31.1
 	rdfs:label	"5q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q31.1#GRCh37
+hco:5q31.1\/GRCh37
 	rdf:type	hco:5q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25855,16 +25855,16 @@ hco:5q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q31.1#GRCh38
+hco:5q31.1\/GRCh38
 	rdf:type	hco:5q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25873,12 +25873,12 @@ hco:5q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131200000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25886,7 +25886,7 @@ hco:5q31.2
 	rdfs:label	"5q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q31.2#GRCh37
+hco:5q31.2\/GRCh37
 	rdf:type	hco:5q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -25895,16 +25895,16 @@ hco:5q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136200000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q31.2#GRCh38
+hco:5q31.2\/GRCh38
 	rdf:type	hco:5q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -25913,12 +25913,12 @@ hco:5q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136900000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25926,7 +25926,7 @@ hco:5q31.3
 	rdfs:label	"5q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q31.3#GRCh37
+hco:5q31.3\/GRCh37
 	rdf:type	hco:5q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -25935,16 +25935,16 @@ hco:5q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	144500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q31.3#GRCh38
+hco:5q31.3\/GRCh38
 	rdf:type	hco:5q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -25953,12 +25953,12 @@ hco:5q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -25966,7 +25966,7 @@ hco:5q32
 	rdfs:label	"5q32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q32#GRCh37
+hco:5q32\/GRCh37
 	rdf:type	hco:5q32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25975,16 +25975,16 @@ hco:5q32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	144500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q32#GRCh38
+hco:5q32\/GRCh38
 	rdf:type	hco:5q32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -25993,12 +25993,12 @@ hco:5q32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26006,7 +26006,7 @@ hco:5q33.1
 	rdfs:label	"5q33.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q33.1#GRCh37
+hco:5q33.1\/GRCh37
 	rdf:type	hco:5q33.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26015,16 +26015,16 @@ hco:5q33.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q33.1#GRCh38
+hco:5q33.1\/GRCh38
 	rdf:type	hco:5q33.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26033,12 +26033,12 @@ hco:5q33.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	150400000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	153300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26046,7 +26046,7 @@ hco:5q33.2
 	rdfs:label	"5q33.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q33.2#GRCh37
+hco:5q33.2\/GRCh37
 	rdf:type	hco:5q33.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26055,16 +26055,16 @@ hco:5q33.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q33.2#GRCh38
+hco:5q33.2\/GRCh38
 	rdf:type	hco:5q33.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26073,12 +26073,12 @@ hco:5q33.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	153300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26086,7 +26086,7 @@ hco:5q33.3
 	rdfs:label	"5q33.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q33.3#GRCh37
+hco:5q33.3\/GRCh37
 	rdf:type	hco:5q33.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26095,16 +26095,16 @@ hco:5q33.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155700000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q33.3#GRCh38
+hco:5q33.3\/GRCh38
 	rdf:type	hco:5q33.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26113,12 +26113,12 @@ hco:5q33.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26126,7 +26126,7 @@ hco:5q34
 	rdfs:label	"5q34" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q34#GRCh37
+hco:5q34\/GRCh37
 	rdf:type	hco:5q34 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26135,16 +26135,16 @@ hco:5q34#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159900000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	168500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q34#GRCh38
+hco:5q34\/GRCh38
 	rdf:type	hco:5q34 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26153,12 +26153,12 @@ hco:5q34#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160500000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26166,7 +26166,7 @@ hco:5q35.1
 	rdfs:label	"5q35.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q35.1#GRCh37
+hco:5q35.1\/GRCh37
 	rdf:type	hco:5q35.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26175,16 +26175,16 @@ hco:5q35.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	168500000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	172800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q35.1#GRCh38
+hco:5q35.1\/GRCh38
 	rdf:type	hco:5q35.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26193,12 +26193,12 @@ hco:5q35.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	169000000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	173300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26206,7 +26206,7 @@ hco:5q35.2
 	rdfs:label	"5q35.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q35.2#GRCh37
+hco:5q35.2\/GRCh37
 	rdf:type	hco:5q35.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26215,16 +26215,16 @@ hco:5q35.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	172800000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q35.2#GRCh38
+hco:5q35.2\/GRCh38
 	rdf:type	hco:5q35.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26233,12 +26233,12 @@ hco:5q35.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	173300000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26246,7 +26246,7 @@ hco:5q35.3
 	rdfs:label	"5q35.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:5q35.3#GRCh37
+hco:5q35.3\/GRCh37
 	rdf:type	hco:5q35.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26255,16 +26255,16 @@ hco:5q35.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	176600000 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	180915260 ;
-			faldo:reference	hco:5#GRCh37
+			faldo:reference	hco:5\/GRCh37
 		]
 	] .
 
-hco:5q35.3#GRCh38
+hco:5q35.3\/GRCh38
 	rdf:type	hco:5q35.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26273,12 +26273,12 @@ hco:5q35.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	177100000 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	181538259 ;
-			faldo:reference	hco:5#GRCh38
+			faldo:reference	hco:5\/GRCh38
 		]
 	] .
 
@@ -26286,7 +26286,7 @@ hco:6p25.3
 	rdfs:label	"6p25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p25.3#GRCh37
+hco:6p25.3\/GRCh37
 	rdf:type	hco:6p25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26295,16 +26295,16 @@ hco:6p25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p25.3#GRCh38
+hco:6p25.3\/GRCh38
 	rdf:type	hco:6p25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26313,12 +26313,12 @@ hco:6p25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26326,7 +26326,7 @@ hco:6p25.2
 	rdfs:label	"6p25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p25.2#GRCh37
+hco:6p25.2\/GRCh37
 	rdf:type	hco:6p25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26335,16 +26335,16 @@ hco:6p25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p25.2#GRCh38
+hco:6p25.2\/GRCh38
 	rdf:type	hco:6p25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26353,12 +26353,12 @@ hco:6p25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26366,7 +26366,7 @@ hco:6p25.1
 	rdfs:label	"6p25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p25.1#GRCh37
+hco:6p25.1\/GRCh37
 	rdf:type	hco:6p25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26375,16 +26375,16 @@ hco:6p25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p25.1#GRCh38
+hco:6p25.1\/GRCh38
 	rdf:type	hco:6p25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26393,12 +26393,12 @@ hco:6p25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26406,7 +26406,7 @@ hco:6p24.3
 	rdfs:label	"6p24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p24.3#GRCh37
+hco:6p24.3\/GRCh37
 	rdf:type	hco:6p24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26415,16 +26415,16 @@ hco:6p24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p24.3#GRCh38
+hco:6p24.3\/GRCh38
 	rdf:type	hco:6p24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26433,12 +26433,12 @@ hco:6p24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26446,7 +26446,7 @@ hco:6p24.2
 	rdfs:label	"6p24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p24.2#GRCh37
+hco:6p24.2\/GRCh37
 	rdf:type	hco:6p24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26455,16 +26455,16 @@ hco:6p24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p24.2#GRCh38
+hco:6p24.2\/GRCh38
 	rdf:type	hco:6p24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26473,12 +26473,12 @@ hco:6p24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26486,7 +26486,7 @@ hco:6p24.1
 	rdfs:label	"6p24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p24.1#GRCh37
+hco:6p24.1\/GRCh37
 	rdf:type	hco:6p24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26495,16 +26495,16 @@ hco:6p24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p24.1#GRCh38
+hco:6p24.1\/GRCh38
 	rdf:type	hco:6p24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26513,12 +26513,12 @@ hco:6p24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26526,7 +26526,7 @@ hco:6p23
 	rdfs:label	"6p23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p23#GRCh37
+hco:6p23\/GRCh37
 	rdf:type	hco:6p23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26535,16 +26535,16 @@ hco:6p23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p23#GRCh38
+hco:6p23\/GRCh38
 	rdf:type	hco:6p23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26553,12 +26553,12 @@ hco:6p23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26566,7 +26566,7 @@ hco:6p22.3
 	rdfs:label	"6p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p22.3#GRCh37
+hco:6p22.3\/GRCh37
 	rdf:type	hco:6p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -26575,16 +26575,16 @@ hco:6p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p22.3#GRCh38
+hco:6p22.3\/GRCh38
 	rdf:type	hco:6p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -26593,12 +26593,12 @@ hco:6p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26606,7 +26606,7 @@ hco:6p22.2
 	rdfs:label	"6p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p22.2#GRCh37
+hco:6p22.2\/GRCh37
 	rdf:type	hco:6p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26615,16 +26615,16 @@ hco:6p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p22.2#GRCh38
+hco:6p22.2\/GRCh38
 	rdf:type	hco:6p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26633,12 +26633,12 @@ hco:6p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26646,7 +26646,7 @@ hco:6p22.1
 	rdfs:label	"6p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p22.1#GRCh37
+hco:6p22.1\/GRCh37
 	rdf:type	hco:6p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26655,16 +26655,16 @@ hco:6p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p22.1#GRCh38
+hco:6p22.1\/GRCh38
 	rdf:type	hco:6p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -26673,12 +26673,12 @@ hco:6p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26686,7 +26686,7 @@ hco:6p21.33
 	rdfs:label	"6p21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p21.33#GRCh37
+hco:6p21.33\/GRCh37
 	rdf:type	hco:6p21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26695,16 +26695,16 @@ hco:6p21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p21.33#GRCh38
+hco:6p21.33\/GRCh38
 	rdf:type	hco:6p21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26713,12 +26713,12 @@ hco:6p21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	30500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26726,7 +26726,7 @@ hco:6p21.32
 	rdfs:label	"6p21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p21.32#GRCh37
+hco:6p21.32\/GRCh37
 	rdf:type	hco:6p21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26735,16 +26735,16 @@ hco:6p21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p21.32#GRCh38
+hco:6p21.32\/GRCh38
 	rdf:type	hco:6p21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26753,12 +26753,12 @@ hco:6p21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	32100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26766,7 +26766,7 @@ hco:6p21.31
 	rdfs:label	"6p21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p21.31#GRCh37
+hco:6p21.31\/GRCh37
 	rdf:type	hco:6p21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26775,16 +26775,16 @@ hco:6p21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p21.31#GRCh38
+hco:6p21.31\/GRCh38
 	rdf:type	hco:6p21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26793,12 +26793,12 @@ hco:6p21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26806,7 +26806,7 @@ hco:6p21.2
 	rdfs:label	"6p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p21.2#GRCh37
+hco:6p21.2\/GRCh37
 	rdf:type	hco:6p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26815,16 +26815,16 @@ hco:6p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p21.2#GRCh38
+hco:6p21.2\/GRCh38
 	rdf:type	hco:6p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -26833,12 +26833,12 @@ hco:6p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26846,7 +26846,7 @@ hco:6p21.1
 	rdfs:label	"6p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p21.1#GRCh37
+hco:6p21.1\/GRCh37
 	rdf:type	hco:6p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26855,16 +26855,16 @@ hco:6p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p21.1#GRCh38
+hco:6p21.1\/GRCh38
 	rdf:type	hco:6p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26873,12 +26873,12 @@ hco:6p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26886,7 +26886,7 @@ hco:6p12.3
 	rdfs:label	"6p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p12.3#GRCh37
+hco:6p12.3\/GRCh37
 	rdf:type	hco:6p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26895,16 +26895,16 @@ hco:6p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p12.3#GRCh38
+hco:6p12.3\/GRCh38
 	rdf:type	hco:6p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26913,12 +26913,12 @@ hco:6p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26926,7 +26926,7 @@ hco:6p12.2
 	rdfs:label	"6p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p12.2#GRCh37
+hco:6p12.2\/GRCh37
 	rdf:type	hco:6p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -26935,16 +26935,16 @@ hco:6p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p12.2#GRCh38
+hco:6p12.2\/GRCh38
 	rdf:type	hco:6p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -26953,12 +26953,12 @@ hco:6p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -26966,7 +26966,7 @@ hco:6p12.1
 	rdfs:label	"6p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p12.1#GRCh37
+hco:6p12.1\/GRCh37
 	rdf:type	hco:6p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26975,16 +26975,16 @@ hco:6p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p12.1#GRCh38
+hco:6p12.1\/GRCh38
 	rdf:type	hco:6p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -26993,12 +26993,12 @@ hco:6p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27006,7 +27006,7 @@ hco:6p11.2
 	rdfs:label	"6p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p11.2#GRCh37
+hco:6p11.2\/GRCh37
 	rdf:type	hco:6p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27015,16 +27015,16 @@ hco:6p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58700000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p11.2#GRCh38
+hco:6p11.2\/GRCh38
 	rdf:type	hco:6p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27033,12 +27033,12 @@ hco:6p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27046,7 +27046,7 @@ hco:6p11.1
 	rdfs:label	"6p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6p11.1#GRCh37
+hco:6p11.1\/GRCh37
 	rdf:type	hco:6p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -27055,16 +27055,16 @@ hco:6p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58700000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6p11.1#GRCh38
+hco:6p11.1\/GRCh38
 	rdf:type	hco:6p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -27073,12 +27073,12 @@ hco:6p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27086,7 +27086,7 @@ hco:6q11.1
 	rdfs:label	"6q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q11.1#GRCh37
+hco:6q11.1\/GRCh37
 	rdf:type	hco:6q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -27095,16 +27095,16 @@ hco:6q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q11.1#GRCh38
+hco:6q11.1\/GRCh38
 	rdf:type	hco:6q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -27113,12 +27113,12 @@ hco:6q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27126,7 +27126,7 @@ hco:6q11.2
 	rdfs:label	"6q11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q11.2#GRCh37
+hco:6q11.2\/GRCh37
 	rdf:type	hco:6q11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27135,16 +27135,16 @@ hco:6q11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q11.2#GRCh38
+hco:6q11.2\/GRCh38
 	rdf:type	hco:6q11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27153,12 +27153,12 @@ hco:6q11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62700000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27166,7 +27166,7 @@ hco:6q12
 	rdfs:label	"6q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q12#GRCh37
+hco:6q12\/GRCh37
 	rdf:type	hco:6q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27175,16 +27175,16 @@ hco:6q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63400000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q12#GRCh38
+hco:6q12\/GRCh38
 	rdf:type	hco:6q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27193,12 +27193,12 @@ hco:6q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62700000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27206,7 +27206,7 @@ hco:6q13
 	rdfs:label	"6q13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q13#GRCh37
+hco:6q13\/GRCh37
 	rdf:type	hco:6q13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27215,16 +27215,16 @@ hco:6q13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q13#GRCh38
+hco:6q13\/GRCh38
 	rdf:type	hco:6q13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27233,12 +27233,12 @@ hco:6q13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27246,7 +27246,7 @@ hco:6q14.1
 	rdfs:label	"6q14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q14.1#GRCh37
+hco:6q14.1\/GRCh37
 	rdf:type	hco:6q14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27255,16 +27255,16 @@ hco:6q14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q14.1#GRCh38
+hco:6q14.1\/GRCh38
 	rdf:type	hco:6q14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27273,12 +27273,12 @@ hco:6q14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	75200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27286,7 +27286,7 @@ hco:6q14.2
 	rdfs:label	"6q14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q14.2#GRCh37
+hco:6q14.2\/GRCh37
 	rdf:type	hco:6q14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27295,16 +27295,16 @@ hco:6q14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q14.2#GRCh38
+hco:6q14.2\/GRCh38
 	rdf:type	hco:6q14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27313,12 +27313,12 @@ hco:6q14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27326,7 +27326,7 @@ hco:6q14.3
 	rdfs:label	"6q14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q14.3#GRCh37
+hco:6q14.3\/GRCh37
 	rdf:type	hco:6q14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27335,16 +27335,16 @@ hco:6q14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84900000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q14.3#GRCh38
+hco:6q14.3\/GRCh38
 	rdf:type	hco:6q14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27353,12 +27353,12 @@ hco:6q14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27366,7 +27366,7 @@ hco:6q15
 	rdfs:label	"6q15" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q15#GRCh37
+hco:6q15\/GRCh37
 	rdf:type	hco:6q15 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27375,16 +27375,16 @@ hco:6q15#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q15#GRCh38
+hco:6q15\/GRCh38
 	rdf:type	hco:6q15 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27393,12 +27393,12 @@ hco:6q15#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27406,7 +27406,7 @@ hco:6q16.1
 	rdfs:label	"6q16.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q16.1#GRCh37
+hco:6q16.1\/GRCh37
 	rdf:type	hco:6q16.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27415,16 +27415,16 @@ hco:6q16.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q16.1#GRCh38
+hco:6q16.1\/GRCh38
 	rdf:type	hco:6q16.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27433,12 +27433,12 @@ hco:6q16.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27446,7 +27446,7 @@ hco:6q16.2
 	rdfs:label	"6q16.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q16.2#GRCh37
+hco:6q16.2\/GRCh37
 	rdf:type	hco:6q16.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27455,16 +27455,16 @@ hco:6q16.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q16.2#GRCh38
+hco:6q16.2\/GRCh38
 	rdf:type	hco:6q16.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27473,12 +27473,12 @@ hco:6q16.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27486,7 +27486,7 @@ hco:6q16.3
 	rdfs:label	"6q16.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q16.3#GRCh37
+hco:6q16.3\/GRCh37
 	rdf:type	hco:6q16.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27495,16 +27495,16 @@ hco:6q16.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q16.3#GRCh38
+hco:6q16.3\/GRCh38
 	rdf:type	hco:6q16.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27513,12 +27513,12 @@ hco:6q16.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27526,7 +27526,7 @@ hco:6q21
 	rdfs:label	"6q21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q21#GRCh37
+hco:6q21\/GRCh37
 	rdf:type	hco:6q21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27535,16 +27535,16 @@ hco:6q21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q21#GRCh38
+hco:6q21\/GRCh38
 	rdf:type	hco:6q21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27553,12 +27553,12 @@ hco:6q21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27566,7 +27566,7 @@ hco:6q22.1
 	rdfs:label	"6q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q22.1#GRCh37
+hco:6q22.1\/GRCh37
 	rdf:type	hco:6q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27575,16 +27575,16 @@ hco:6q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q22.1#GRCh38
+hco:6q22.1\/GRCh38
 	rdf:type	hco:6q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27593,12 +27593,12 @@ hco:6q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27606,7 +27606,7 @@ hco:6q22.2
 	rdfs:label	"6q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q22.2#GRCh37
+hco:6q22.2\/GRCh37
 	rdf:type	hco:6q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27615,16 +27615,16 @@ hco:6q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q22.2#GRCh38
+hco:6q22.2\/GRCh38
 	rdf:type	hco:6q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27633,12 +27633,12 @@ hco:6q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27646,7 +27646,7 @@ hco:6q22.31
 	rdfs:label	"6q22.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q22.31#GRCh37
+hco:6q22.31\/GRCh37
 	rdf:type	hco:6q22.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27655,16 +27655,16 @@ hco:6q22.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q22.31#GRCh38
+hco:6q22.31\/GRCh38
 	rdf:type	hco:6q22.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -27673,12 +27673,12 @@ hco:6q22.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27686,7 +27686,7 @@ hco:6q22.32
 	rdfs:label	"6q22.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q22.32#GRCh37
+hco:6q22.32\/GRCh37
 	rdf:type	hco:6q22.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27695,16 +27695,16 @@ hco:6q22.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q22.32#GRCh38
+hco:6q22.32\/GRCh38
 	rdf:type	hco:6q22.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27713,12 +27713,12 @@ hco:6q22.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27726,7 +27726,7 @@ hco:6q22.33
 	rdfs:label	"6q22.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q22.33#GRCh37
+hco:6q22.33\/GRCh37
 	rdf:type	hco:6q22.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27735,16 +27735,16 @@ hco:6q22.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127100000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q22.33#GRCh38
+hco:6q22.33\/GRCh38
 	rdf:type	hco:6q22.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27753,12 +27753,12 @@ hco:6q22.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126800000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27766,7 +27766,7 @@ hco:6q23.1
 	rdfs:label	"6q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q23.1#GRCh37
+hco:6q23.1\/GRCh37
 	rdf:type	hco:6q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27775,16 +27775,16 @@ hco:6q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130300000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q23.1#GRCh38
+hco:6q23.1\/GRCh38
 	rdf:type	hco:6q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27793,12 +27793,12 @@ hco:6q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130000000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27806,7 +27806,7 @@ hco:6q23.2
 	rdfs:label	"6q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q23.2#GRCh37
+hco:6q23.2\/GRCh37
 	rdf:type	hco:6q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27815,16 +27815,16 @@ hco:6q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q23.2#GRCh38
+hco:6q23.2\/GRCh38
 	rdf:type	hco:6q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -27833,12 +27833,12 @@ hco:6q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130900000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134700000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27846,7 +27846,7 @@ hco:6q23.3
 	rdfs:label	"6q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q23.3#GRCh37
+hco:6q23.3\/GRCh37
 	rdf:type	hco:6q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27855,16 +27855,16 @@ hco:6q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135200000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q23.3#GRCh38
+hco:6q23.3\/GRCh38
 	rdf:type	hco:6q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27873,12 +27873,12 @@ hco:6q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134700000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27886,7 +27886,7 @@ hco:6q24.1
 	rdfs:label	"6q24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q24.1#GRCh37
+hco:6q24.1\/GRCh37
 	rdf:type	hco:6q24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27895,16 +27895,16 @@ hco:6q24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142800000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q24.1#GRCh38
+hco:6q24.1\/GRCh38
 	rdf:type	hco:6q24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27913,12 +27913,12 @@ hco:6q24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138300000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27926,7 +27926,7 @@ hco:6q24.2
 	rdfs:label	"6q24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q24.2#GRCh37
+hco:6q24.2\/GRCh37
 	rdf:type	hco:6q24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -27935,16 +27935,16 @@ hco:6q24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142800000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q24.2#GRCh38
+hco:6q24.2\/GRCh38
 	rdf:type	hco:6q24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -27953,12 +27953,12 @@ hco:6q24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -27966,7 +27966,7 @@ hco:6q24.3
 	rdfs:label	"6q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q24.3#GRCh37
+hco:6q24.3\/GRCh37
 	rdf:type	hco:6q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27975,16 +27975,16 @@ hco:6q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145600000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q24.3#GRCh38
+hco:6q24.3\/GRCh38
 	rdf:type	hco:6q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -27993,12 +27993,12 @@ hco:6q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28006,7 +28006,7 @@ hco:6q25.1
 	rdfs:label	"6q25.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q25.1#GRCh37
+hco:6q25.1\/GRCh37
 	rdf:type	hco:6q25.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28015,16 +28015,16 @@ hco:6q25.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	149000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q25.1#GRCh38
+hco:6q25.1\/GRCh38
 	rdf:type	hco:6q25.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28033,12 +28033,12 @@ hco:6q25.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148500000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28046,7 +28046,7 @@ hco:6q25.2
 	rdfs:label	"6q25.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q25.2#GRCh37
+hco:6q25.2\/GRCh37
 	rdf:type	hco:6q25.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28055,16 +28055,16 @@ hco:6q25.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q25.2#GRCh38
+hco:6q25.2\/GRCh38
 	rdf:type	hco:6q25.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28073,12 +28073,12 @@ hco:6q25.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28086,7 +28086,7 @@ hco:6q25.3
 	rdfs:label	"6q25.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q25.3#GRCh37
+hco:6q25.3\/GRCh37
 	rdf:type	hco:6q25.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28095,16 +28095,16 @@ hco:6q25.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q25.3#GRCh38
+hco:6q25.3\/GRCh38
 	rdf:type	hco:6q25.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28113,12 +28113,12 @@ hco:6q25.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155200000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28126,7 +28126,7 @@ hco:6q26
 	rdfs:label	"6q26" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q26#GRCh37
+hco:6q26\/GRCh37
 	rdf:type	hco:6q26 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28135,16 +28135,16 @@ hco:6q26#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	161000000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q26#GRCh38
+hco:6q26\/GRCh38
 	rdf:type	hco:6q26 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28153,12 +28153,12 @@ hco:6q26#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	160600000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28166,7 +28166,7 @@ hco:6q27
 	rdfs:label	"6q27" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:6q27#GRCh37
+hco:6q27\/GRCh37
 	rdf:type	hco:6q27 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28175,16 +28175,16 @@ hco:6q27#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164500000 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	171115067 ;
-			faldo:reference	hco:6#GRCh37
+			faldo:reference	hco:6\/GRCh37
 		]
 	] .
 
-hco:6q27#GRCh38
+hco:6q27\/GRCh38
 	rdf:type	hco:6q27 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28193,12 +28193,12 @@ hco:6q27#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	164100000 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	170805979 ;
-			faldo:reference	hco:6#GRCh38
+			faldo:reference	hco:6\/GRCh38
 		]
 	] .
 
@@ -28206,7 +28206,7 @@ hco:7p22.3
 	rdfs:label	"7p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p22.3#GRCh37
+hco:7p22.3\/GRCh37
 	rdf:type	hco:7p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28215,16 +28215,16 @@ hco:7p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p22.3#GRCh38
+hco:7p22.3\/GRCh38
 	rdf:type	hco:7p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28233,12 +28233,12 @@ hco:7p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28246,7 +28246,7 @@ hco:7p22.2
 	rdfs:label	"7p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p22.2#GRCh37
+hco:7p22.2\/GRCh37
 	rdf:type	hco:7p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -28255,16 +28255,16 @@ hco:7p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p22.2#GRCh38
+hco:7p22.2\/GRCh38
 	rdf:type	hco:7p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -28273,12 +28273,12 @@ hco:7p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28286,7 +28286,7 @@ hco:7p22.1
 	rdfs:label	"7p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p22.1#GRCh37
+hco:7p22.1\/GRCh37
 	rdf:type	hco:7p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28295,16 +28295,16 @@ hco:7p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7300000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p22.1#GRCh38
+hco:7p22.1\/GRCh38
 	rdf:type	hco:7p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28313,12 +28313,12 @@ hco:7p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28326,7 +28326,7 @@ hco:7p21.3
 	rdfs:label	"7p21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p21.3#GRCh37
+hco:7p21.3\/GRCh37
 	rdf:type	hco:7p21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -28335,16 +28335,16 @@ hco:7p21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7300000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p21.3#GRCh38
+hco:7p21.3\/GRCh38
 	rdf:type	hco:7p21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -28353,12 +28353,12 @@ hco:7p21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	7200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28366,7 +28366,7 @@ hco:7p21.2
 	rdfs:label	"7p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p21.2#GRCh37
+hco:7p21.2\/GRCh37
 	rdf:type	hco:7p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28375,16 +28375,16 @@ hco:7p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p21.2#GRCh38
+hco:7p21.2\/GRCh38
 	rdf:type	hco:7p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28393,12 +28393,12 @@ hco:7p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28406,7 +28406,7 @@ hco:7p21.1
 	rdfs:label	"7p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p21.1#GRCh37
+hco:7p21.1\/GRCh37
 	rdf:type	hco:7p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -28415,16 +28415,16 @@ hco:7p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p21.1#GRCh38
+hco:7p21.1\/GRCh38
 	rdf:type	hco:7p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -28433,12 +28433,12 @@ hco:7p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28446,7 +28446,7 @@ hco:7p15.3
 	rdfs:label	"7p15.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p15.3#GRCh37
+hco:7p15.3\/GRCh37
 	rdf:type	hco:7p15.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28455,16 +28455,16 @@ hco:7p15.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p15.3#GRCh38
+hco:7p15.3\/GRCh38
 	rdf:type	hco:7p15.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28473,12 +28473,12 @@ hco:7p15.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	20900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28486,7 +28486,7 @@ hco:7p15.2
 	rdfs:label	"7p15.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p15.2#GRCh37
+hco:7p15.2\/GRCh37
 	rdf:type	hco:7p15.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28495,16 +28495,16 @@ hco:7p15.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p15.2#GRCh38
+hco:7p15.2\/GRCh38
 	rdf:type	hco:7p15.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -28513,12 +28513,12 @@ hco:7p15.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28526,7 +28526,7 @@ hco:7p15.1
 	rdfs:label	"7p15.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p15.1#GRCh37
+hco:7p15.1\/GRCh37
 	rdf:type	hco:7p15.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28535,16 +28535,16 @@ hco:7p15.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p15.1#GRCh38
+hco:7p15.1\/GRCh38
 	rdf:type	hco:7p15.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28553,12 +28553,12 @@ hco:7p15.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28566,7 +28566,7 @@ hco:7p14.3
 	rdfs:label	"7p14.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p14.3#GRCh37
+hco:7p14.3\/GRCh37
 	rdf:type	hco:7p14.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28575,16 +28575,16 @@ hco:7p14.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p14.3#GRCh38
+hco:7p14.3\/GRCh38
 	rdf:type	hco:7p14.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28593,12 +28593,12 @@ hco:7p14.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28606,7 +28606,7 @@ hco:7p14.2
 	rdfs:label	"7p14.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p14.2#GRCh37
+hco:7p14.2\/GRCh37
 	rdf:type	hco:7p14.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28615,16 +28615,16 @@ hco:7p14.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	35000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p14.2#GRCh38
+hco:7p14.2\/GRCh38
 	rdf:type	hco:7p14.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28633,12 +28633,12 @@ hco:7p14.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	34900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28646,7 +28646,7 @@ hco:7p14.1
 	rdfs:label	"7p14.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p14.1#GRCh37
+hco:7p14.1\/GRCh37
 	rdf:type	hco:7p14.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28655,16 +28655,16 @@ hco:7p14.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p14.1#GRCh38
+hco:7p14.1\/GRCh38
 	rdf:type	hco:7p14.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28673,12 +28673,12 @@ hco:7p14.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28686,7 +28686,7 @@ hco:7p13
 	rdfs:label	"7p13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p13#GRCh37
+hco:7p13\/GRCh37
 	rdf:type	hco:7p13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28695,16 +28695,16 @@ hco:7p13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p13#GRCh38
+hco:7p13\/GRCh38
 	rdf:type	hco:7p13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28713,12 +28713,12 @@ hco:7p13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43300000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28726,7 +28726,7 @@ hco:7p12.3
 	rdfs:label	"7p12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p12.3#GRCh37
+hco:7p12.3\/GRCh37
 	rdf:type	hco:7p12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28735,16 +28735,16 @@ hco:7p12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p12.3#GRCh38
+hco:7p12.3\/GRCh38
 	rdf:type	hco:7p12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28753,12 +28753,12 @@ hco:7p12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28766,7 +28766,7 @@ hco:7p12.2
 	rdfs:label	"7p12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p12.2#GRCh37
+hco:7p12.2\/GRCh37
 	rdf:type	hco:7p12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28775,16 +28775,16 @@ hco:7p12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p12.2#GRCh38
+hco:7p12.2\/GRCh38
 	rdf:type	hco:7p12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28793,12 +28793,12 @@ hco:7p12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28806,7 +28806,7 @@ hco:7p12.1
 	rdfs:label	"7p12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p12.1#GRCh37
+hco:7p12.1\/GRCh37
 	rdf:type	hco:7p12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28815,16 +28815,16 @@ hco:7p12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p12.1#GRCh38
+hco:7p12.1\/GRCh38
 	rdf:type	hco:7p12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -28833,12 +28833,12 @@ hco:7p12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28846,7 +28846,7 @@ hco:7p11.2
 	rdfs:label	"7p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p11.2#GRCh37
+hco:7p11.2\/GRCh37
 	rdf:type	hco:7p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28855,16 +28855,16 @@ hco:7p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p11.2#GRCh38
+hco:7p11.2\/GRCh38
 	rdf:type	hco:7p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28873,12 +28873,12 @@ hco:7p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	53900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28886,7 +28886,7 @@ hco:7p11.1
 	rdfs:label	"7p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7p11.1#GRCh37
+hco:7p11.1\/GRCh37
 	rdf:type	hco:7p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -28895,16 +28895,16 @@ hco:7p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7p11.1#GRCh38
+hco:7p11.1\/GRCh38
 	rdf:type	hco:7p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -28913,12 +28913,12 @@ hco:7p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28926,7 +28926,7 @@ hco:7q11.1
 	rdfs:label	"7q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q11.1#GRCh37
+hco:7q11.1\/GRCh37
 	rdf:type	hco:7q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -28935,16 +28935,16 @@ hco:7q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61700000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q11.1#GRCh38
+hco:7q11.1\/GRCh38
 	rdf:type	hco:7q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -28953,12 +28953,12 @@ hco:7q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -28966,7 +28966,7 @@ hco:7q11.21
 	rdfs:label	"7q11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q11.21#GRCh37
+hco:7q11.21\/GRCh37
 	rdf:type	hco:7q11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -28975,16 +28975,16 @@ hco:7q11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61700000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q11.21#GRCh38
+hco:7q11.21\/GRCh38
 	rdf:type	hco:7q11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -28993,12 +28993,12 @@ hco:7q11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29006,7 +29006,7 @@ hco:7q11.22
 	rdfs:label	"7q11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q11.22#GRCh37
+hco:7q11.22\/GRCh37
 	rdf:type	hco:7q11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29015,16 +29015,16 @@ hco:7q11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q11.22#GRCh38
+hco:7q11.22\/GRCh38
 	rdf:type	hco:7q11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29033,12 +29033,12 @@ hco:7q11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29046,7 +29046,7 @@ hco:7q11.23
 	rdfs:label	"7q11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q11.23#GRCh37
+hco:7q11.23\/GRCh37
 	rdf:type	hco:7q11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29055,16 +29055,16 @@ hco:7q11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q11.23#GRCh38
+hco:7q11.23\/GRCh38
 	rdf:type	hco:7q11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29073,12 +29073,12 @@ hco:7q11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29086,7 +29086,7 @@ hco:7q21.11
 	rdfs:label	"7q21.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q21.11#GRCh37
+hco:7q21.11\/GRCh37
 	rdf:type	hco:7q21.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -29095,16 +29095,16 @@ hco:7q21.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q21.11#GRCh38
+hco:7q21.11\/GRCh38
 	rdf:type	hco:7q21.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -29113,12 +29113,12 @@ hco:7q21.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	77900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29126,7 +29126,7 @@ hco:7q21.12
 	rdfs:label	"7q21.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q21.12#GRCh37
+hco:7q21.12\/GRCh37
 	rdf:type	hco:7q21.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29135,16 +29135,16 @@ hco:7q21.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q21.12#GRCh38
+hco:7q21.12\/GRCh38
 	rdf:type	hco:7q21.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29153,12 +29153,12 @@ hco:7q21.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29166,7 +29166,7 @@ hco:7q21.13
 	rdfs:label	"7q21.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q21.13#GRCh37
+hco:7q21.13\/GRCh37
 	rdf:type	hco:7q21.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29175,16 +29175,16 @@ hco:7q21.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q21.13#GRCh38
+hco:7q21.13\/GRCh38
 	rdf:type	hco:7q21.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29193,12 +29193,12 @@ hco:7q21.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	88500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29206,7 +29206,7 @@ hco:7q21.2
 	rdfs:label	"7q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q21.2#GRCh37
+hco:7q21.2\/GRCh37
 	rdf:type	hco:7q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29215,16 +29215,16 @@ hco:7q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q21.2#GRCh38
+hco:7q21.2\/GRCh38
 	rdf:type	hco:7q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29233,12 +29233,12 @@ hco:7q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29246,7 +29246,7 @@ hco:7q21.3
 	rdfs:label	"7q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q21.3#GRCh37
+hco:7q21.3\/GRCh37
 	rdf:type	hco:7q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29255,16 +29255,16 @@ hco:7q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q21.3#GRCh38
+hco:7q21.3\/GRCh38
 	rdf:type	hco:7q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29273,12 +29273,12 @@ hco:7q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29286,7 +29286,7 @@ hco:7q22.1
 	rdfs:label	"7q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q22.1#GRCh37
+hco:7q22.1\/GRCh37
 	rdf:type	hco:7q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29295,16 +29295,16 @@ hco:7q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98000000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q22.1#GRCh38
+hco:7q22.1\/GRCh38
 	rdf:type	hco:7q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29313,12 +29313,12 @@ hco:7q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29326,7 +29326,7 @@ hco:7q22.2
 	rdfs:label	"7q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q22.2#GRCh37
+hco:7q22.2\/GRCh37
 	rdf:type	hco:7q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29335,16 +29335,16 @@ hco:7q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q22.2#GRCh38
+hco:7q22.2\/GRCh38
 	rdf:type	hco:7q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29353,12 +29353,12 @@ hco:7q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29366,7 +29366,7 @@ hco:7q22.3
 	rdfs:label	"7q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q22.3#GRCh37
+hco:7q22.3\/GRCh37
 	rdf:type	hco:7q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29375,16 +29375,16 @@ hco:7q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q22.3#GRCh38
+hco:7q22.3\/GRCh38
 	rdf:type	hco:7q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29393,12 +29393,12 @@ hco:7q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29406,7 +29406,7 @@ hco:7q31.1
 	rdfs:label	"7q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q31.1#GRCh37
+hco:7q31.1\/GRCh37
 	rdf:type	hco:7q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29415,16 +29415,16 @@ hco:7q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q31.1#GRCh38
+hco:7q31.1\/GRCh38
 	rdf:type	hco:7q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29433,12 +29433,12 @@ hco:7q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	107800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115000000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29446,7 +29446,7 @@ hco:7q31.2
 	rdfs:label	"7q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q31.2#GRCh37
+hco:7q31.2\/GRCh37
 	rdf:type	hco:7q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29455,16 +29455,16 @@ hco:7q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q31.2#GRCh38
+hco:7q31.2\/GRCh38
 	rdf:type	hco:7q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29473,12 +29473,12 @@ hco:7q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	115000000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29486,7 +29486,7 @@ hco:7q31.31
 	rdfs:label	"7q31.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q31.31#GRCh37
+hco:7q31.31\/GRCh37
 	rdf:type	hco:7q31.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29495,16 +29495,16 @@ hco:7q31.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q31.31#GRCh38
+hco:7q31.31\/GRCh38
 	rdf:type	hco:7q31.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29513,12 +29513,12 @@ hco:7q31.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29526,7 +29526,7 @@ hco:7q31.32
 	rdfs:label	"7q31.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q31.32#GRCh37
+hco:7q31.32\/GRCh37
 	rdf:type	hco:7q31.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29535,16 +29535,16 @@ hco:7q31.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q31.32#GRCh38
+hco:7q31.32\/GRCh38
 	rdf:type	hco:7q31.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29553,12 +29553,12 @@ hco:7q31.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29566,7 +29566,7 @@ hco:7q31.33
 	rdfs:label	"7q31.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q31.33#GRCh37
+hco:7q31.33\/GRCh37
 	rdf:type	hco:7q31.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29575,16 +29575,16 @@ hco:7q31.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123800000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q31.33#GRCh38
+hco:7q31.33\/GRCh38
 	rdf:type	hco:7q31.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29593,12 +29593,12 @@ hco:7q31.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	124100000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29606,7 +29606,7 @@ hco:7q32.1
 	rdfs:label	"7q32.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q32.1#GRCh37
+hco:7q32.1\/GRCh37
 	rdf:type	hco:7q32.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29615,16 +29615,16 @@ hco:7q32.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q32.1#GRCh38
+hco:7q32.1\/GRCh38
 	rdf:type	hco:7q32.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29633,12 +29633,12 @@ hco:7q32.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129600000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29646,7 +29646,7 @@ hco:7q32.2
 	rdfs:label	"7q32.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q32.2#GRCh37
+hco:7q32.2\/GRCh37
 	rdf:type	hco:7q32.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -29655,16 +29655,16 @@ hco:7q32.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q32.2#GRCh38
+hco:7q32.2\/GRCh38
 	rdf:type	hco:7q32.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -29673,12 +29673,12 @@ hco:7q32.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129600000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29686,7 +29686,7 @@ hco:7q32.3
 	rdfs:label	"7q32.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q32.3#GRCh37
+hco:7q32.3\/GRCh37
 	rdf:type	hco:7q32.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29695,16 +29695,16 @@ hco:7q32.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q32.3#GRCh38
+hco:7q32.3\/GRCh38
 	rdf:type	hco:7q32.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29713,12 +29713,12 @@ hco:7q32.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29726,7 +29726,7 @@ hco:7q33
 	rdfs:label	"7q33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q33#GRCh37
+hco:7q33\/GRCh37
 	rdf:type	hco:7q33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29735,16 +29735,16 @@ hco:7q33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q33#GRCh38
+hco:7q33\/GRCh38
 	rdf:type	hco:7q33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -29753,12 +29753,12 @@ hco:7q33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	132900000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29766,7 +29766,7 @@ hco:7q34
 	rdfs:label	"7q34" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q34#GRCh37
+hco:7q34\/GRCh37
 	rdf:type	hco:7q34 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29775,16 +29775,16 @@ hco:7q34#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138200000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q34#GRCh38
+hco:7q34\/GRCh38
 	rdf:type	hco:7q34 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29793,12 +29793,12 @@ hco:7q34#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138500000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29806,7 +29806,7 @@ hco:7q35
 	rdfs:label	"7q35" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q35#GRCh37
+hco:7q35\/GRCh37
 	rdf:type	hco:7q35 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29815,16 +29815,16 @@ hco:7q35#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q35#GRCh38
+hco:7q35\/GRCh38
 	rdf:type	hco:7q35 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -29833,12 +29833,12 @@ hco:7q35#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143400000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29846,7 +29846,7 @@ hco:7q36.1
 	rdfs:label	"7q36.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q36.1#GRCh37
+hco:7q36.1\/GRCh37
 	rdf:type	hco:7q36.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29855,16 +29855,16 @@ hco:7q36.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147900000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q36.1#GRCh38
+hco:7q36.1\/GRCh38
 	rdf:type	hco:7q36.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29873,12 +29873,12 @@ hco:7q36.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29886,7 +29886,7 @@ hco:7q36.2
 	rdfs:label	"7q36.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q36.2#GRCh37
+hco:7q36.2\/GRCh37
 	rdf:type	hco:7q36.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -29895,16 +29895,16 @@ hco:7q36.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152600000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q36.2#GRCh38
+hco:7q36.2\/GRCh38
 	rdf:type	hco:7q36.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -29913,12 +29913,12 @@ hco:7q36.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	152800000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29926,7 +29926,7 @@ hco:7q36.3
 	rdfs:label	"7q36.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:7q36.3#GRCh37
+hco:7q36.3\/GRCh37
 	rdf:type	hco:7q36.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29935,16 +29935,16 @@ hco:7q36.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155100000 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159138663 ;
-			faldo:reference	hco:7#GRCh37
+			faldo:reference	hco:7\/GRCh37
 		]
 	] .
 
-hco:7q36.3#GRCh38
+hco:7q36.3\/GRCh38
 	rdf:type	hco:7q36.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29953,12 +29953,12 @@ hco:7q36.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155200000 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	159345973 ;
-			faldo:reference	hco:7#GRCh38
+			faldo:reference	hco:7\/GRCh38
 		]
 	] .
 
@@ -29966,7 +29966,7 @@ hco:8p23.3
 	rdfs:label	"8p23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p23.3#GRCh37
+hco:8p23.3\/GRCh37
 	rdf:type	hco:8p23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -29975,16 +29975,16 @@ hco:8p23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p23.3#GRCh38
+hco:8p23.3\/GRCh38
 	rdf:type	hco:8p23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -29993,12 +29993,12 @@ hco:8p23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30006,7 +30006,7 @@ hco:8p23.2
 	rdfs:label	"8p23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p23.2#GRCh37
+hco:8p23.2\/GRCh37
 	rdf:type	hco:8p23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30015,16 +30015,16 @@ hco:8p23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p23.2#GRCh38
+hco:8p23.2\/GRCh38
 	rdf:type	hco:8p23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30033,12 +30033,12 @@ hco:8p23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30046,7 +30046,7 @@ hco:8p23.1
 	rdfs:label	"8p23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p23.1#GRCh37
+hco:8p23.1\/GRCh37
 	rdf:type	hco:8p23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30055,16 +30055,16 @@ hco:8p23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p23.1#GRCh38
+hco:8p23.1\/GRCh38
 	rdf:type	hco:8p23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30073,12 +30073,12 @@ hco:8p23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12800000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30086,7 +30086,7 @@ hco:8p22
 	rdfs:label	"8p22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p22#GRCh37
+hco:8p22\/GRCh37
 	rdf:type	hco:8p22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -30095,16 +30095,16 @@ hco:8p22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p22#GRCh38
+hco:8p22\/GRCh38
 	rdf:type	hco:8p22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -30113,12 +30113,12 @@ hco:8p22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12800000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30126,7 +30126,7 @@ hco:8p21.3
 	rdfs:label	"8p21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p21.3#GRCh37
+hco:8p21.3\/GRCh37
 	rdf:type	hco:8p21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30135,16 +30135,16 @@ hco:8p21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p21.3#GRCh38
+hco:8p21.3\/GRCh38
 	rdf:type	hco:8p21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30153,12 +30153,12 @@ hco:8p21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30166,7 +30166,7 @@ hco:8p21.2
 	rdfs:label	"8p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p21.2#GRCh37
+hco:8p21.2\/GRCh37
 	rdf:type	hco:8p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30175,16 +30175,16 @@ hco:8p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27400000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p21.2#GRCh38
+hco:8p21.2\/GRCh38
 	rdf:type	hco:8p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30193,12 +30193,12 @@ hco:8p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30206,7 +30206,7 @@ hco:8p21.1
 	rdfs:label	"8p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p21.1#GRCh37
+hco:8p21.1\/GRCh37
 	rdf:type	hco:8p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30215,16 +30215,16 @@ hco:8p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27400000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p21.1#GRCh38
+hco:8p21.1\/GRCh38
 	rdf:type	hco:8p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30233,12 +30233,12 @@ hco:8p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	27500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29000000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30246,7 +30246,7 @@ hco:8p12
 	rdfs:label	"8p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p12#GRCh37
+hco:8p12\/GRCh37
 	rdf:type	hco:8p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30255,16 +30255,16 @@ hco:8p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p12#GRCh38
+hco:8p12\/GRCh38
 	rdf:type	hco:8p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30273,12 +30273,12 @@ hco:8p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29000000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30286,7 +30286,7 @@ hco:8p11.23
 	rdfs:label	"8p11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p11.23#GRCh37
+hco:8p11.23\/GRCh37
 	rdf:type	hco:8p11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30295,16 +30295,16 @@ hco:8p11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p11.23#GRCh38
+hco:8p11.23\/GRCh38
 	rdf:type	hco:8p11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30313,12 +30313,12 @@ hco:8p11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30326,7 +30326,7 @@ hco:8p11.22
 	rdfs:label	"8p11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p11.22#GRCh37
+hco:8p11.22\/GRCh37
 	rdf:type	hco:8p11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -30335,16 +30335,16 @@ hco:8p11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p11.22#GRCh38
+hco:8p11.22\/GRCh38
 	rdf:type	hco:8p11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -30353,12 +30353,12 @@ hco:8p11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30366,7 +30366,7 @@ hco:8p11.21
 	rdfs:label	"8p11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p11.21#GRCh37
+hco:8p11.21\/GRCh37
 	rdf:type	hco:8p11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30375,16 +30375,16 @@ hco:8p11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p11.21#GRCh38
+hco:8p11.21\/GRCh38
 	rdf:type	hco:8p11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30393,12 +30393,12 @@ hco:8p11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30406,7 +30406,7 @@ hco:8p11.1
 	rdfs:label	"8p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8p11.1#GRCh37
+hco:8p11.1\/GRCh37
 	rdf:type	hco:8p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -30415,16 +30415,16 @@ hco:8p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8p11.1#GRCh38
+hco:8p11.1\/GRCh38
 	rdf:type	hco:8p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -30433,12 +30433,12 @@ hco:8p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30446,7 +30446,7 @@ hco:8q11.1
 	rdfs:label	"8q11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q11.1#GRCh37
+hco:8q11.1\/GRCh37
 	rdf:type	hco:8q11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -30455,16 +30455,16 @@ hco:8q11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q11.1#GRCh38
+hco:8q11.1\/GRCh38
 	rdf:type	hco:8q11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -30473,12 +30473,12 @@ hco:8q11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30486,7 +30486,7 @@ hco:8q11.21
 	rdfs:label	"8q11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q11.21#GRCh37
+hco:8q11.21\/GRCh37
 	rdf:type	hco:8q11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30495,16 +30495,16 @@ hco:8q11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	48100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q11.21#GRCh38
+hco:8q11.21\/GRCh38
 	rdf:type	hco:8q11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30513,12 +30513,12 @@ hco:8q11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47200000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30526,7 +30526,7 @@ hco:8q11.22
 	rdfs:label	"8q11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q11.22#GRCh37
+hco:8q11.22\/GRCh37
 	rdf:type	hco:8q11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30535,16 +30535,16 @@ hco:8q11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q11.22#GRCh38
+hco:8q11.22\/GRCh38
 	rdf:type	hco:8q11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30553,12 +30553,12 @@ hco:8q11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30566,7 +30566,7 @@ hco:8q11.23
 	rdfs:label	"8q11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q11.23#GRCh37
+hco:8q11.23\/GRCh37
 	rdf:type	hco:8q11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30575,16 +30575,16 @@ hco:8q11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	52600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q11.23#GRCh38
+hco:8q11.23\/GRCh38
 	rdf:type	hco:8q11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30593,12 +30593,12 @@ hco:8q11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	51700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30606,7 +30606,7 @@ hco:8q12.1
 	rdfs:label	"8q12.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q12.1#GRCh37
+hco:8q12.1\/GRCh37
 	rdf:type	hco:8q12.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30615,16 +30615,16 @@ hco:8q12.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	55500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q12.1#GRCh38
+hco:8q12.1\/GRCh38
 	rdf:type	hco:8q12.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30633,12 +30633,12 @@ hco:8q12.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30646,7 +30646,7 @@ hco:8q12.2
 	rdfs:label	"8q12.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q12.2#GRCh37
+hco:8q12.2\/GRCh37
 	rdf:type	hco:8q12.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30655,16 +30655,16 @@ hco:8q12.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q12.2#GRCh38
+hco:8q12.2\/GRCh38
 	rdf:type	hco:8q12.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30673,12 +30673,12 @@ hco:8q12.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30686,7 +30686,7 @@ hco:8q12.3
 	rdfs:label	"8q12.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q12.3#GRCh37
+hco:8q12.3\/GRCh37
 	rdf:type	hco:8q12.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30695,16 +30695,16 @@ hco:8q12.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	62200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q12.3#GRCh38
+hco:8q12.3\/GRCh38
 	rdf:type	hco:8q12.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30713,12 +30713,12 @@ hco:8q12.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30726,7 +30726,7 @@ hco:8q13.1
 	rdfs:label	"8q13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q13.1#GRCh37
+hco:8q13.1\/GRCh37
 	rdf:type	hco:8q13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30735,16 +30735,16 @@ hco:8q13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	66000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q13.1#GRCh38
+hco:8q13.1\/GRCh38
 	rdf:type	hco:8q13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30753,12 +30753,12 @@ hco:8q13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30766,7 +30766,7 @@ hco:8q13.2
 	rdfs:label	"8q13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q13.2#GRCh37
+hco:8q13.2\/GRCh37
 	rdf:type	hco:8q13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30775,16 +30775,16 @@ hco:8q13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q13.2#GRCh38
+hco:8q13.2\/GRCh38
 	rdf:type	hco:8q13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -30793,12 +30793,12 @@ hco:8q13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30806,7 +30806,7 @@ hco:8q13.3
 	rdfs:label	"8q13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q13.3#GRCh37
+hco:8q13.3\/GRCh37
 	rdf:type	hco:8q13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30815,16 +30815,16 @@ hco:8q13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	70500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q13.3#GRCh38
+hco:8q13.3\/GRCh38
 	rdf:type	hco:8q13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30833,12 +30833,12 @@ hco:8q13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72000000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30846,7 +30846,7 @@ hco:8q21.11
 	rdfs:label	"8q21.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q21.11#GRCh37
+hco:8q21.11\/GRCh37
 	rdf:type	hco:8q21.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -30855,16 +30855,16 @@ hco:8q21.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q21.11#GRCh38
+hco:8q21.11\/GRCh38
 	rdf:type	hco:8q21.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -30873,12 +30873,12 @@ hco:8q21.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72000000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30886,7 +30886,7 @@ hco:8q21.12
 	rdfs:label	"8q21.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q21.12#GRCh37
+hco:8q21.12\/GRCh37
 	rdf:type	hco:8q21.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30895,16 +30895,16 @@ hco:8q21.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q21.12#GRCh38
+hco:8q21.12\/GRCh38
 	rdf:type	hco:8q21.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30913,12 +30913,12 @@ hco:8q21.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74600000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30926,7 +30926,7 @@ hco:8q21.13
 	rdfs:label	"8q21.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q21.13#GRCh37
+hco:8q21.13\/GRCh37
 	rdf:type	hco:8q21.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30935,16 +30935,16 @@ hco:8q21.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	80100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q21.13#GRCh38
+hco:8q21.13\/GRCh38
 	rdf:type	hco:8q21.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -30953,12 +30953,12 @@ hco:8q21.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -30966,7 +30966,7 @@ hco:8q21.2
 	rdfs:label	"8q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q21.2#GRCh37
+hco:8q21.2\/GRCh37
 	rdf:type	hco:8q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -30975,16 +30975,16 @@ hco:8q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q21.2#GRCh38
+hco:8q21.2\/GRCh38
 	rdf:type	hco:8q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -30993,12 +30993,12 @@ hco:8q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	83500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31006,7 +31006,7 @@ hco:8q21.3
 	rdfs:label	"8q21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q21.3#GRCh37
+hco:8q21.3\/GRCh37
 	rdf:type	hco:8q21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31015,16 +31015,16 @@ hco:8q21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q21.3#GRCh38
+hco:8q21.3\/GRCh38
 	rdf:type	hco:8q21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31033,12 +31033,12 @@ hco:8q21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31046,7 +31046,7 @@ hco:8q22.1
 	rdfs:label	"8q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q22.1#GRCh37
+hco:8q22.1\/GRCh37
 	rdf:type	hco:8q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31055,16 +31055,16 @@ hco:8q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q22.1#GRCh38
+hco:8q22.1\/GRCh38
 	rdf:type	hco:8q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31073,12 +31073,12 @@ hco:8q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31086,7 +31086,7 @@ hco:8q22.2
 	rdfs:label	"8q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q22.2#GRCh37
+hco:8q22.2\/GRCh37
 	rdf:type	hco:8q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31095,16 +31095,16 @@ hco:8q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99000000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q22.2#GRCh38
+hco:8q22.2\/GRCh38
 	rdf:type	hco:8q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31113,12 +31113,12 @@ hco:8q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	97900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31126,7 +31126,7 @@ hco:8q22.3
 	rdfs:label	"8q22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q22.3#GRCh37
+hco:8q22.3\/GRCh37
 	rdf:type	hco:8q22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31135,16 +31135,16 @@ hco:8q22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	101600000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q22.3#GRCh38
+hco:8q22.3\/GRCh38
 	rdf:type	hco:8q22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31153,12 +31153,12 @@ hco:8q22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	100500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31166,7 +31166,7 @@ hco:8q23.1
 	rdfs:label	"8q23.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q23.1#GRCh37
+hco:8q23.1\/GRCh37
 	rdf:type	hco:8q23.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31175,16 +31175,16 @@ hco:8q23.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	106200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q23.1#GRCh38
+hco:8q23.1\/GRCh38
 	rdf:type	hco:8q23.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31193,12 +31193,12 @@ hco:8q23.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31206,7 +31206,7 @@ hco:8q23.2
 	rdfs:label	"8q23.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q23.2#GRCh37
+hco:8q23.2\/GRCh37
 	rdf:type	hco:8q23.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31215,16 +31215,16 @@ hco:8q23.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	110500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q23.2#GRCh38
+hco:8q23.2\/GRCh38
 	rdf:type	hco:8q23.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31233,12 +31233,12 @@ hco:8q23.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31246,7 +31246,7 @@ hco:8q23.3
 	rdfs:label	"8q23.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q23.3#GRCh37
+hco:8q23.3\/GRCh37
 	rdf:type	hco:8q23.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31255,16 +31255,16 @@ hco:8q23.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112100000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q23.3#GRCh38
+hco:8q23.3\/GRCh38
 	rdf:type	hco:8q23.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31273,12 +31273,12 @@ hco:8q23.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111100000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31286,7 +31286,7 @@ hco:8q24.11
 	rdfs:label	"8q24.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.11#GRCh37
+hco:8q24.11\/GRCh37
 	rdf:type	hco:8q24.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31295,16 +31295,16 @@ hco:8q24.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.11#GRCh38
+hco:8q24.11\/GRCh38
 	rdf:type	hco:8q24.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31313,12 +31313,12 @@ hco:8q24.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116700000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31326,7 +31326,7 @@ hco:8q24.12
 	rdfs:label	"8q24.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.12#GRCh37
+hco:8q24.12\/GRCh37
 	rdf:type	hco:8q24.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -31335,16 +31335,16 @@ hco:8q24.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119200000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.12#GRCh38
+hco:8q24.12\/GRCh38
 	rdf:type	hco:8q24.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -31353,12 +31353,12 @@ hco:8q24.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	118300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31366,7 +31366,7 @@ hco:8q24.13
 	rdfs:label	"8q24.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.13#GRCh37
+hco:8q24.13\/GRCh37
 	rdf:type	hco:8q24.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31375,16 +31375,16 @@ hco:8q24.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.13#GRCh38
+hco:8q24.13\/GRCh38
 	rdf:type	hco:8q24.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31393,12 +31393,12 @@ hco:8q24.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121500000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31406,7 +31406,7 @@ hco:8q24.21
 	rdfs:label	"8q24.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.21#GRCh37
+hco:8q24.21\/GRCh37
 	rdf:type	hco:8q24.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -31415,16 +31415,16 @@ hco:8q24.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127300000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.21#GRCh38
+hco:8q24.21\/GRCh38
 	rdf:type	hco:8q24.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -31433,12 +31433,12 @@ hco:8q24.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	126300000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31446,7 +31446,7 @@ hco:8q24.22
 	rdfs:label	"8q24.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.22#GRCh37
+hco:8q24.22\/GRCh37
 	rdf:type	hco:8q24.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31455,16 +31455,16 @@ hco:8q24.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131500000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136400000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.22#GRCh38
+hco:8q24.22\/GRCh38
 	rdf:type	hco:8q24.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31473,12 +31473,12 @@ hco:8q24.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135400000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31486,7 +31486,7 @@ hco:8q24.23
 	rdfs:label	"8q24.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.23#GRCh37
+hco:8q24.23\/GRCh37
 	rdf:type	hco:8q24.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31495,16 +31495,16 @@ hco:8q24.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	136400000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.23#GRCh38
+hco:8q24.23\/GRCh38
 	rdf:type	hco:8q24.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31513,12 +31513,12 @@ hco:8q24.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135400000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31526,7 +31526,7 @@ hco:8q24.3
 	rdfs:label	"8q24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:8q24.3#GRCh37
+hco:8q24.3\/GRCh37
 	rdf:type	hco:8q24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31535,16 +31535,16 @@ hco:8q24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	139900000 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	146364022 ;
-			faldo:reference	hco:8#GRCh37
+			faldo:reference	hco:8\/GRCh37
 		]
 	] .
 
-hco:8q24.3#GRCh38
+hco:8q24.3\/GRCh38
 	rdf:type	hco:8q24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31553,12 +31553,12 @@ hco:8q24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138900000 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	145138636 ;
-			faldo:reference	hco:8#GRCh38
+			faldo:reference	hco:8\/GRCh38
 		]
 	] .
 
@@ -31566,7 +31566,7 @@ hco:9p24.3
 	rdfs:label	"9p24.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p24.3#GRCh37
+hco:9p24.3\/GRCh37
 	rdf:type	hco:9p24.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31575,16 +31575,16 @@ hco:9p24.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p24.3#GRCh38
+hco:9p24.3\/GRCh38
 	rdf:type	hco:9p24.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31593,12 +31593,12 @@ hco:9p24.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31606,7 +31606,7 @@ hco:9p24.2
 	rdfs:label	"9p24.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p24.2#GRCh37
+hco:9p24.2\/GRCh37
 	rdf:type	hco:9p24.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31615,16 +31615,16 @@ hco:9p24.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p24.2#GRCh38
+hco:9p24.2\/GRCh38
 	rdf:type	hco:9p24.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31633,12 +31633,12 @@ hco:9p24.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31646,7 +31646,7 @@ hco:9p24.1
 	rdfs:label	"9p24.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p24.1#GRCh37
+hco:9p24.1\/GRCh37
 	rdf:type	hco:9p24.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31655,16 +31655,16 @@ hco:9p24.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p24.1#GRCh38
+hco:9p24.1\/GRCh38
 	rdf:type	hco:9p24.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31673,12 +31673,12 @@ hco:9p24.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31686,7 +31686,7 @@ hco:9p23
 	rdfs:label	"9p23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p23#GRCh37
+hco:9p23\/GRCh37
 	rdf:type	hco:9p23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31695,16 +31695,16 @@ hco:9p23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p23#GRCh38
+hco:9p23\/GRCh38
 	rdf:type	hco:9p23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -31713,12 +31713,12 @@ hco:9p23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31726,7 +31726,7 @@ hco:9p22.3
 	rdfs:label	"9p22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p22.3#GRCh37
+hco:9p22.3\/GRCh37
 	rdf:type	hco:9p22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31735,16 +31735,16 @@ hco:9p22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p22.3#GRCh38
+hco:9p22.3\/GRCh38
 	rdf:type	hco:9p22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31753,12 +31753,12 @@ hco:9p22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	14200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31766,7 +31766,7 @@ hco:9p22.2
 	rdfs:label	"9p22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p22.2#GRCh37
+hco:9p22.2\/GRCh37
 	rdf:type	hco:9p22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31775,16 +31775,16 @@ hco:9p22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p22.2#GRCh38
+hco:9p22.2\/GRCh38
 	rdf:type	hco:9p22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -31793,12 +31793,12 @@ hco:9p22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	16600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31806,7 +31806,7 @@ hco:9p22.1
 	rdfs:label	"9p22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p22.1#GRCh37
+hco:9p22.1\/GRCh37
 	rdf:type	hco:9p22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31815,16 +31815,16 @@ hco:9p22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p22.1#GRCh38
+hco:9p22.1\/GRCh38
 	rdf:type	hco:9p22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31833,12 +31833,12 @@ hco:9p22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	18500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31846,7 +31846,7 @@ hco:9p21.3
 	rdfs:label	"9p21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p21.3#GRCh37
+hco:9p21.3\/GRCh37
 	rdf:type	hco:9p21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31855,16 +31855,16 @@ hco:9p21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p21.3#GRCh38
+hco:9p21.3\/GRCh38
 	rdf:type	hco:9p21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31873,12 +31873,12 @@ hco:9p21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31886,7 +31886,7 @@ hco:9p21.2
 	rdfs:label	"9p21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p21.2#GRCh37
+hco:9p21.2\/GRCh37
 	rdf:type	hco:9p21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31895,16 +31895,16 @@ hco:9p21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p21.2#GRCh38
+hco:9p21.2\/GRCh38
 	rdf:type	hco:9p21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31913,12 +31913,12 @@ hco:9p21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	25600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31926,7 +31926,7 @@ hco:9p21.1
 	rdfs:label	"9p21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p21.1#GRCh37
+hco:9p21.1\/GRCh37
 	rdf:type	hco:9p21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31935,16 +31935,16 @@ hco:9p21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p21.1#GRCh38
+hco:9p21.1\/GRCh38
 	rdf:type	hco:9p21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -31953,12 +31953,12 @@ hco:9p21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -31966,7 +31966,7 @@ hco:9p13.3
 	rdfs:label	"9p13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p13.3#GRCh37
+hco:9p13.3\/GRCh37
 	rdf:type	hco:9p13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -31975,16 +31975,16 @@ hco:9p13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p13.3#GRCh38
+hco:9p13.3\/GRCh38
 	rdf:type	hco:9p13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -31993,12 +31993,12 @@ hco:9p13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	33200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32006,7 +32006,7 @@ hco:9p13.2
 	rdfs:label	"9p13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p13.2#GRCh37
+hco:9p13.2\/GRCh37
 	rdf:type	hco:9p13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32015,16 +32015,16 @@ hco:9p13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p13.2#GRCh38
+hco:9p13.2\/GRCh38
 	rdf:type	hco:9p13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32033,12 +32033,12 @@ hco:9p13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	36300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32046,7 +32046,7 @@ hco:9p13.1
 	rdfs:label	"9p13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p13.1#GRCh37
+hco:9p13.1\/GRCh37
 	rdf:type	hco:9p13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32055,16 +32055,16 @@ hco:9p13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	38400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p13.1#GRCh38
+hco:9p13.1\/GRCh38
 	rdf:type	hco:9p13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32073,12 +32073,12 @@ hco:9p13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32086,7 +32086,7 @@ hco:9p12
 	rdfs:label	"9p12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p12#GRCh37
+hco:9p12\/GRCh37
 	rdf:type	hco:9p12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32095,16 +32095,16 @@ hco:9p12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	41000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p12#GRCh38
+hco:9p12\/GRCh38
 	rdf:type	hco:9p12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32113,12 +32113,12 @@ hco:9p12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	39000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32126,7 +32126,7 @@ hco:9p11.2
 	rdfs:label	"9p11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p11.2#GRCh37
+hco:9p11.2\/GRCh37
 	rdf:type	hco:9p11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32135,16 +32135,16 @@ hco:9p11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p11.2#GRCh38
+hco:9p11.2\/GRCh38
 	rdf:type	hco:9p11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32153,12 +32153,12 @@ hco:9p11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	40000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32166,7 +32166,7 @@ hco:9p11.1
 	rdfs:label	"9p11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9p11.1#GRCh37
+hco:9p11.1\/GRCh37
 	rdf:type	hco:9p11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -32175,16 +32175,16 @@ hco:9p11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9p11.1#GRCh38
+hco:9p11.1\/GRCh38
 	rdf:type	hco:9p11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -32193,12 +32193,12 @@ hco:9p11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32206,7 +32206,7 @@ hco:9q11
 	rdfs:label	"9q11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q11#GRCh37
+hco:9q11\/GRCh37
 	rdf:type	hco:9q11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -32215,16 +32215,16 @@ hco:9q11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q11#GRCh38
+hco:9q11\/GRCh38
 	rdf:type	hco:9q11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -32233,12 +32233,12 @@ hco:9q11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	43000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32246,7 +32246,7 @@ hco:9q12
 	rdfs:label	"9q12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q12#GRCh37
+hco:9q12\/GRCh37
 	rdf:type	hco:9q12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -32255,16 +32255,16 @@ hco:9q12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q12#GRCh38
+hco:9q12\/GRCh38
 	rdf:type	hco:9q12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -32273,12 +32273,12 @@ hco:9q12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	45500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32286,7 +32286,7 @@ hco:9q13
 	rdfs:label	"9q13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q13#GRCh37
+hco:9q13\/GRCh37
 	rdf:type	hco:9q13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32295,16 +32295,16 @@ hco:9q13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q13#GRCh38
+hco:9q13\/GRCh38
 	rdf:type	hco:9q13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32313,12 +32313,12 @@ hco:9q13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32326,7 +32326,7 @@ hco:9q21.11
 	rdfs:label	"9q21.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.11#GRCh37
+hco:9q21.11\/GRCh37
 	rdf:type	hco:9q21.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32335,16 +32335,16 @@ hco:9q21.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.11#GRCh38
+hco:9q21.11\/GRCh38
 	rdf:type	hco:9q21.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32353,12 +32353,12 @@ hco:9q21.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65000000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32366,7 +32366,7 @@ hco:9q21.12
 	rdfs:label	"9q21.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.12#GRCh37
+hco:9q21.12\/GRCh37
 	rdf:type	hco:9q21.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32375,16 +32375,16 @@ hco:9q21.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	72200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.12#GRCh38
+hco:9q21.12\/GRCh38
 	rdf:type	hco:9q21.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32393,12 +32393,12 @@ hco:9q21.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	69300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32406,7 +32406,7 @@ hco:9q21.13
 	rdfs:label	"9q21.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.13#GRCh37
+hco:9q21.13\/GRCh37
 	rdf:type	hco:9q21.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32415,16 +32415,16 @@ hco:9q21.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.13#GRCh38
+hco:9q21.13\/GRCh38
 	rdf:type	hco:9q21.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32433,12 +32433,12 @@ hco:9q21.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32446,7 +32446,7 @@ hco:9q21.2
 	rdfs:label	"9q21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.2#GRCh37
+hco:9q21.2\/GRCh37
 	rdf:type	hco:9q21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32455,16 +32455,16 @@ hco:9q21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	79200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81100000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.2#GRCh38
+hco:9q21.2\/GRCh38
 	rdf:type	hco:9q21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32473,12 +32473,12 @@ hco:9q21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32486,7 +32486,7 @@ hco:9q21.31
 	rdfs:label	"9q21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.31#GRCh37
+hco:9q21.31\/GRCh37
 	rdf:type	hco:9q21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32495,16 +32495,16 @@ hco:9q21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81100000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.31#GRCh38
+hco:9q21.31\/GRCh38
 	rdf:type	hco:9q21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32513,12 +32513,12 @@ hco:9q21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	78500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32526,7 +32526,7 @@ hco:9q21.32
 	rdfs:label	"9q21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.32#GRCh37
+hco:9q21.32\/GRCh37
 	rdf:type	hco:9q21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32535,16 +32535,16 @@ hco:9q21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84100000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.32#GRCh38
+hco:9q21.32\/GRCh38
 	rdf:type	hco:9q21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32553,12 +32553,12 @@ hco:9q21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	81500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32566,7 +32566,7 @@ hco:9q21.33
 	rdfs:label	"9q21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q21.33#GRCh37
+hco:9q21.33\/GRCh37
 	rdf:type	hco:9q21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32575,16 +32575,16 @@ hco:9q21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q21.33#GRCh38
+hco:9q21.33\/GRCh38
 	rdf:type	hco:9q21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -32593,12 +32593,12 @@ hco:9q21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84300000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32606,7 +32606,7 @@ hco:9q22.1
 	rdfs:label	"9q22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q22.1#GRCh37
+hco:9q22.1\/GRCh37
 	rdf:type	hco:9q22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32615,16 +32615,16 @@ hco:9q22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	90400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q22.1#GRCh38
+hco:9q22.1\/GRCh38
 	rdf:type	hco:9q22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32633,12 +32633,12 @@ hco:9q22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32646,7 +32646,7 @@ hco:9q22.2
 	rdfs:label	"9q22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q22.2#GRCh37
+hco:9q22.2\/GRCh37
 	rdf:type	hco:9q22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32655,16 +32655,16 @@ hco:9q22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q22.2#GRCh38
+hco:9q22.2\/GRCh38
 	rdf:type	hco:9q22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32673,12 +32673,12 @@ hco:9q22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	89200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32686,7 +32686,7 @@ hco:9q22.31
 	rdfs:label	"9q22.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q22.31#GRCh37
+hco:9q22.31\/GRCh37
 	rdf:type	hco:9q22.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32695,16 +32695,16 @@ hco:9q22.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q22.31#GRCh38
+hco:9q22.31\/GRCh38
 	rdf:type	hco:9q22.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32713,12 +32713,12 @@ hco:9q22.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91200000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32726,7 +32726,7 @@ hco:9q22.32
 	rdfs:label	"9q22.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q22.32#GRCh37
+hco:9q22.32\/GRCh37
 	rdf:type	hco:9q22.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32735,16 +32735,16 @@ hco:9q22.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q22.32#GRCh38
+hco:9q22.32\/GRCh38
 	rdf:type	hco:9q22.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32753,12 +32753,12 @@ hco:9q22.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32766,7 +32766,7 @@ hco:9q22.33
 	rdfs:label	"9q22.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q22.33#GRCh37
+hco:9q22.33\/GRCh37
 	rdf:type	hco:9q22.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32775,16 +32775,16 @@ hco:9q22.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q22.33#GRCh38
+hco:9q22.33\/GRCh38
 	rdf:type	hco:9q22.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32793,12 +32793,12 @@ hco:9q22.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	96500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32806,7 +32806,7 @@ hco:9q31.1
 	rdfs:label	"9q31.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q31.1#GRCh37
+hco:9q31.1\/GRCh37
 	rdf:type	hco:9q31.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -32815,16 +32815,16 @@ hco:9q31.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102600000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q31.1#GRCh38
+hco:9q31.1\/GRCh38
 	rdf:type	hco:9q31.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -32833,12 +32833,12 @@ hco:9q31.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105400000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32846,7 +32846,7 @@ hco:9q31.2
 	rdfs:label	"9q31.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q31.2#GRCh37
+hco:9q31.2\/GRCh37
 	rdf:type	hco:9q31.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32855,16 +32855,16 @@ hco:9q31.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108200000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q31.2#GRCh38
+hco:9q31.2\/GRCh38
 	rdf:type	hco:9q31.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32873,12 +32873,12 @@ hco:9q31.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	105400000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32886,7 +32886,7 @@ hco:9q31.3
 	rdfs:label	"9q31.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q31.3#GRCh37
+hco:9q31.3\/GRCh37
 	rdf:type	hco:9q31.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32895,16 +32895,16 @@ hco:9q31.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	111300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q31.3#GRCh38
+hco:9q31.3\/GRCh38
 	rdf:type	hco:9q31.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -32913,12 +32913,12 @@ hco:9q31.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32926,7 +32926,7 @@ hco:9q32
 	rdfs:label	"9q32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q32#GRCh37
+hco:9q32\/GRCh37
 	rdf:type	hco:9q32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -32935,16 +32935,16 @@ hco:9q32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q32#GRCh38
+hco:9q32\/GRCh38
 	rdf:type	hco:9q32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -32953,12 +32953,12 @@ hco:9q32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	112100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -32966,7 +32966,7 @@ hco:9q33.1
 	rdfs:label	"9q33.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q33.1#GRCh37
+hco:9q33.1\/GRCh37
 	rdf:type	hco:9q33.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -32975,16 +32975,16 @@ hco:9q33.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117700000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q33.1#GRCh38
+hco:9q33.1\/GRCh38
 	rdf:type	hco:9q33.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -32993,12 +32993,12 @@ hco:9q33.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	114900000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33006,7 +33006,7 @@ hco:9q33.2
 	rdfs:label	"9q33.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q33.2#GRCh37
+hco:9q33.2\/GRCh37
 	rdf:type	hco:9q33.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33015,16 +33015,16 @@ hco:9q33.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	122500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q33.2#GRCh38
+hco:9q33.2\/GRCh38
 	rdf:type	hco:9q33.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33033,12 +33033,12 @@ hco:9q33.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	119800000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33046,7 +33046,7 @@ hco:9q33.3
 	rdfs:label	"9q33.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q33.3#GRCh37
+hco:9q33.3\/GRCh37
 	rdf:type	hco:9q33.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33055,16 +33055,16 @@ hco:9q33.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	125800000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q33.3#GRCh38
+hco:9q33.3\/GRCh38
 	rdf:type	hco:9q33.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33073,12 +33073,12 @@ hco:9q33.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	123100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33086,7 +33086,7 @@ hco:9q34.11
 	rdfs:label	"9q34.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q34.11#GRCh37
+hco:9q34.11\/GRCh37
 	rdf:type	hco:9q34.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33095,16 +33095,16 @@ hco:9q34.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130300000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q34.11#GRCh38
+hco:9q34.11\/GRCh38
 	rdf:type	hco:9q34.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33113,12 +33113,12 @@ hco:9q34.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	127500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33126,7 +33126,7 @@ hco:9q34.12
 	rdfs:label	"9q34.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q34.12#GRCh37
+hco:9q34.12\/GRCh37
 	rdf:type	hco:9q34.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33135,16 +33135,16 @@ hco:9q34.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133500000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q34.12#GRCh38
+hco:9q34.12\/GRCh38
 	rdf:type	hco:9q34.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33153,12 +33153,12 @@ hco:9q34.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130600000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33166,7 +33166,7 @@ hco:9q34.13
 	rdfs:label	"9q34.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q34.13#GRCh37
+hco:9q34.13\/GRCh37
 	rdf:type	hco:9q34.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33175,16 +33175,16 @@ hco:9q34.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134000000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q34.13#GRCh38
+hco:9q34.13\/GRCh38
 	rdf:type	hco:9q34.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33193,12 +33193,12 @@ hco:9q34.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33206,7 +33206,7 @@ hco:9q34.2
 	rdfs:label	"9q34.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q34.2#GRCh37
+hco:9q34.2\/GRCh37
 	rdf:type	hco:9q34.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33215,16 +33215,16 @@ hco:9q34.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	135900000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	137400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q34.2#GRCh38
+hco:9q34.2\/GRCh38
 	rdf:type	hco:9q34.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33233,12 +33233,12 @@ hco:9q34.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133100000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33246,7 +33246,7 @@ hco:9q34.3
 	rdfs:label	"9q34.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:9q34.3#GRCh37
+hco:9q34.3\/GRCh37
 	rdf:type	hco:9q34.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33255,16 +33255,16 @@ hco:9q34.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	137400000 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141213431 ;
-			faldo:reference	hco:9#GRCh37
+			faldo:reference	hco:9\/GRCh37
 		]
 	] .
 
-hco:9q34.3#GRCh38
+hco:9q34.3\/GRCh38
 	rdf:type	hco:9q34.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33273,12 +33273,12 @@ hco:9q34.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134500000 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138394717 ;
-			faldo:reference	hco:9#GRCh38
+			faldo:reference	hco:9\/GRCh38
 		]
 	] .
 
@@ -33286,7 +33286,7 @@ hco:Xp22.33
 	rdfs:label	"Xp22.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.33#GRCh37
+hco:Xp22.33\/GRCh37
 	rdf:type	hco:Xp22.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33295,16 +33295,16 @@ hco:Xp22.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.33#GRCh38
+hco:Xp22.33\/GRCh38
 	rdf:type	hco:Xp22.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33313,12 +33313,12 @@ hco:Xp22.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33326,7 +33326,7 @@ hco:Xp22.32
 	rdfs:label	"Xp22.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.32#GRCh37
+hco:Xp22.32\/GRCh37
 	rdf:type	hco:Xp22.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33335,16 +33335,16 @@ hco:Xp22.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.32#GRCh38
+hco:Xp22.32\/GRCh38
 	rdf:type	hco:Xp22.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33353,12 +33353,12 @@ hco:Xp22.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	4400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33366,7 +33366,7 @@ hco:Xp22.31
 	rdfs:label	"Xp22.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.31#GRCh37
+hco:Xp22.31\/GRCh37
 	rdf:type	hco:Xp22.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33375,16 +33375,16 @@ hco:Xp22.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.31#GRCh38
+hco:Xp22.31\/GRCh38
 	rdf:type	hco:Xp22.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33393,12 +33393,12 @@ hco:Xp22.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	6100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9600000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33406,7 +33406,7 @@ hco:Xp22.2
 	rdfs:label	"Xp22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.2#GRCh37
+hco:Xp22.2\/GRCh37
 	rdf:type	hco:Xp22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33415,16 +33415,16 @@ hco:Xp22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.2#GRCh38
+hco:Xp22.2\/GRCh38
 	rdf:type	hco:Xp22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33433,12 +33433,12 @@ hco:Xp22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	9600000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33446,7 +33446,7 @@ hco:Xp22.13
 	rdfs:label	"Xp22.13" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.13#GRCh37
+hco:Xp22.13\/GRCh37
 	rdf:type	hco:Xp22.13 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33455,16 +33455,16 @@ hco:Xp22.13#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.13#GRCh38
+hco:Xp22.13\/GRCh38
 	rdf:type	hco:Xp22.13 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33473,12 +33473,12 @@ hco:Xp22.13#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33486,7 +33486,7 @@ hco:Xp22.12
 	rdfs:label	"Xp22.12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.12#GRCh37
+hco:Xp22.12\/GRCh37
 	rdf:type	hco:Xp22.12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33495,16 +33495,16 @@ hco:Xp22.12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.12#GRCh38
+hco:Xp22.12\/GRCh38
 	rdf:type	hco:Xp22.12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -33513,12 +33513,12 @@ hco:Xp22.12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19200000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33526,7 +33526,7 @@ hco:Xp22.11
 	rdfs:label	"Xp22.11" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp22.11#GRCh37
+hco:Xp22.11\/GRCh37
 	rdf:type	hco:Xp22.11 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33535,16 +33535,16 @@ hco:Xp22.11#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp22.11#GRCh38
+hco:Xp22.11\/GRCh38
 	rdf:type	hco:Xp22.11 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33553,12 +33553,12 @@ hco:Xp22.11#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	21900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33566,7 +33566,7 @@ hco:Xp21.3
 	rdfs:label	"Xp21.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp21.3#GRCh37
+hco:Xp21.3\/GRCh37
 	rdf:type	hco:Xp21.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -33575,16 +33575,16 @@ hco:Xp21.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp21.3#GRCh38
+hco:Xp21.3\/GRCh38
 	rdf:type	hco:Xp21.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -33593,12 +33593,12 @@ hco:Xp21.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	24900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33606,7 +33606,7 @@ hco:Xp21.2
 	rdfs:label	"Xp21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp21.2#GRCh37
+hco:Xp21.2\/GRCh37
 	rdf:type	hco:Xp21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33615,16 +33615,16 @@ hco:Xp21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp21.2#GRCh38
+hco:Xp21.2\/GRCh38
 	rdf:type	hco:Xp21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33633,12 +33633,12 @@ hco:Xp21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	29300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33646,7 +33646,7 @@ hco:Xp21.1
 	rdfs:label	"Xp21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp21.1#GRCh37
+hco:Xp21.1\/GRCh37
 	rdf:type	hco:Xp21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -33655,16 +33655,16 @@ hco:Xp21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp21.1#GRCh38
+hco:Xp21.1\/GRCh38
 	rdf:type	hco:Xp21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -33673,12 +33673,12 @@ hco:Xp21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	31500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33686,7 +33686,7 @@ hco:Xp11.4
 	rdfs:label	"Xp11.4" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.4#GRCh37
+hco:Xp11.4\/GRCh37
 	rdf:type	hco:Xp11.4 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33695,16 +33695,16 @@ hco:Xp11.4#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.4#GRCh38
+hco:Xp11.4\/GRCh38
 	rdf:type	hco:Xp11.4 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33713,12 +33713,12 @@ hco:Xp11.4#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	37800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33726,7 +33726,7 @@ hco:Xp11.3
 	rdfs:label	"Xp11.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.3#GRCh37
+hco:Xp11.3\/GRCh37
 	rdf:type	hco:Xp11.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -33735,16 +33735,16 @@ hco:Xp11.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.3#GRCh38
+hco:Xp11.3\/GRCh38
 	rdf:type	hco:Xp11.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -33753,12 +33753,12 @@ hco:Xp11.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	42500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47600000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33766,7 +33766,7 @@ hco:Xp11.23
 	rdfs:label	"Xp11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.23#GRCh37
+hco:Xp11.23\/GRCh37
 	rdf:type	hco:Xp11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33775,16 +33775,16 @@ hco:Xp11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	46400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.23#GRCh38
+hco:Xp11.23\/GRCh38
 	rdf:type	hco:Xp11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33793,12 +33793,12 @@ hco:Xp11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	47600000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33806,7 +33806,7 @@ hco:Xp11.22
 	rdfs:label	"Xp11.22" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.22#GRCh37
+hco:Xp11.22\/GRCh37
 	rdf:type	hco:Xp11.22 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33815,16 +33815,16 @@ hco:Xp11.22#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	49800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.22#GRCh38
+hco:Xp11.22\/GRCh38
 	rdf:type	hco:Xp11.22 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -33833,12 +33833,12 @@ hco:Xp11.22#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	50100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33846,7 +33846,7 @@ hco:Xp11.21
 	rdfs:label	"Xp11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.21#GRCh37
+hco:Xp11.21\/GRCh37
 	rdf:type	hco:Xp11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33855,16 +33855,16 @@ hco:Xp11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.21#GRCh38
+hco:Xp11.21\/GRCh38
 	rdf:type	hco:Xp11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33873,12 +33873,12 @@ hco:Xp11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	54800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33886,7 +33886,7 @@ hco:Xp11.1
 	rdfs:label	"Xp11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xp11.1#GRCh37
+hco:Xp11.1\/GRCh37
 	rdf:type	hco:Xp11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -33895,16 +33895,16 @@ hco:Xp11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xp11.1#GRCh38
+hco:Xp11.1\/GRCh38
 	rdf:type	hco:Xp11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -33913,12 +33913,12 @@ hco:Xp11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	58100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33926,7 +33926,7 @@ hco:Xq11.1
 	rdfs:label	"Xq11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq11.1#GRCh37
+hco:Xq11.1\/GRCh37
 	rdf:type	hco:Xq11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -33935,16 +33935,16 @@ hco:Xq11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	60600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq11.1#GRCh38
+hco:Xq11.1\/GRCh38
 	rdf:type	hco:Xq11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -33953,12 +33953,12 @@ hco:Xq11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	61000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -33966,7 +33966,7 @@ hco:Xq11.2
 	rdfs:label	"Xq11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq11.2#GRCh37
+hco:Xq11.2\/GRCh37
 	rdf:type	hco:Xq11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -33975,16 +33975,16 @@ hco:Xq11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq11.2#GRCh38
+hco:Xq11.2\/GRCh38
 	rdf:type	hco:Xq11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -33993,12 +33993,12 @@ hco:Xq11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	63800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34006,7 +34006,7 @@ hco:Xq12
 	rdfs:label	"Xq12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq12#GRCh37
+hco:Xq12\/GRCh37
 	rdf:type	hco:Xq12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34015,16 +34015,16 @@ hco:Xq12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	64600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq12#GRCh38
+hco:Xq12\/GRCh38
 	rdf:type	hco:Xq12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34033,12 +34033,12 @@ hco:Xq12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	65400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34046,7 +34046,7 @@ hco:Xq13.1
 	rdfs:label	"Xq13.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq13.1#GRCh37
+hco:Xq13.1\/GRCh37
 	rdf:type	hco:Xq13.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34055,16 +34055,16 @@ hco:Xq13.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	67800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq13.1#GRCh38
+hco:Xq13.1\/GRCh38
 	rdf:type	hco:Xq13.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34073,12 +34073,12 @@ hco:Xq13.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	68500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34086,7 +34086,7 @@ hco:Xq13.2
 	rdfs:label	"Xq13.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq13.2#GRCh37
+hco:Xq13.2\/GRCh37
 	rdf:type	hco:Xq13.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34095,16 +34095,16 @@ hco:Xq13.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	71800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq13.2#GRCh38
+hco:Xq13.2\/GRCh38
 	rdf:type	hco:Xq13.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34113,12 +34113,12 @@ hco:Xq13.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74700000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34126,7 +34126,7 @@ hco:Xq13.3
 	rdfs:label	"Xq13.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq13.3#GRCh37
+hco:Xq13.3\/GRCh37
 	rdf:type	hco:Xq13.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34135,16 +34135,16 @@ hco:Xq13.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	73900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq13.3#GRCh38
+hco:Xq13.3\/GRCh38
 	rdf:type	hco:Xq13.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34153,12 +34153,12 @@ hco:Xq13.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	74700000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34166,7 +34166,7 @@ hco:Xq21.1
 	rdfs:label	"Xq21.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq21.1#GRCh37
+hco:Xq21.1\/GRCh37
 	rdf:type	hco:Xq21.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34175,16 +34175,16 @@ hco:Xq21.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq21.1#GRCh38
+hco:Xq21.1\/GRCh38
 	rdf:type	hco:Xq21.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34193,12 +34193,12 @@ hco:Xq21.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	76800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34206,7 +34206,7 @@ hco:Xq21.2
 	rdfs:label	"Xq21.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq21.2#GRCh37
+hco:Xq21.2\/GRCh37
 	rdf:type	hco:Xq21.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34215,16 +34215,16 @@ hco:Xq21.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	84600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86200000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq21.2#GRCh38
+hco:Xq21.2\/GRCh38
 	rdf:type	hco:Xq21.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34233,12 +34233,12 @@ hco:Xq21.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	85400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34246,7 +34246,7 @@ hco:Xq21.31
 	rdfs:label	"Xq21.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq21.31#GRCh37
+hco:Xq21.31\/GRCh37
 	rdf:type	hco:Xq21.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34255,16 +34255,16 @@ hco:Xq21.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	86200000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq21.31#GRCh38
+hco:Xq21.31\/GRCh38
 	rdf:type	hco:Xq21.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34273,12 +34273,12 @@ hco:Xq21.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	87000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92700000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34286,7 +34286,7 @@ hco:Xq21.32
 	rdfs:label	"Xq21.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq21.32#GRCh37
+hco:Xq21.32\/GRCh37
 	rdf:type	hco:Xq21.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34295,16 +34295,16 @@ hco:Xq21.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	91800000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq21.32#GRCh38
+hco:Xq21.32\/GRCh38
 	rdf:type	hco:Xq21.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34313,12 +34313,12 @@ hco:Xq21.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	92700000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34326,7 +34326,7 @@ hco:Xq21.33
 	rdfs:label	"Xq21.33" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq21.33#GRCh37
+hco:Xq21.33\/GRCh37
 	rdf:type	hco:Xq21.33 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34335,16 +34335,16 @@ hco:Xq21.33#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	93500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq21.33#GRCh38
+hco:Xq21.33\/GRCh38
 	rdf:type	hco:Xq21.33 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34353,12 +34353,12 @@ hco:Xq21.33#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	94300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34366,7 +34366,7 @@ hco:Xq22.1
 	rdfs:label	"Xq22.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq22.1#GRCh37
+hco:Xq22.1\/GRCh37
 	rdf:type	hco:Xq22.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34375,16 +34375,16 @@ hco:Xq22.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	98300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq22.1#GRCh38
+hco:Xq22.1\/GRCh38
 	rdf:type	hco:Xq22.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34393,12 +34393,12 @@ hco:Xq22.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	99100000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34406,7 +34406,7 @@ hco:Xq22.2
 	rdfs:label	"Xq22.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq22.2#GRCh37
+hco:Xq22.2\/GRCh37
 	rdf:type	hco:Xq22.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34415,16 +34415,16 @@ hco:Xq22.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	102600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq22.2#GRCh38
+hco:Xq22.2\/GRCh38
 	rdf:type	hco:Xq22.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34433,12 +34433,12 @@ hco:Xq22.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34446,7 +34446,7 @@ hco:Xq22.3
 	rdfs:label	"Xq22.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq22.3#GRCh37
+hco:Xq22.3\/GRCh37
 	rdf:type	hco:Xq22.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34455,16 +34455,16 @@ hco:Xq22.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	103700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq22.3#GRCh38
+hco:Xq22.3\/GRCh38
 	rdf:type	hco:Xq22.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34473,12 +34473,12 @@ hco:Xq22.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	104500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34486,7 +34486,7 @@ hco:Xq23
 	rdfs:label	"Xq23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq23#GRCh37
+hco:Xq23\/GRCh37
 	rdf:type	hco:Xq23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34495,16 +34495,16 @@ hco:Xq23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	108700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq23#GRCh38
+hco:Xq23\/GRCh38
 	rdf:type	hco:Xq23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34513,12 +34513,12 @@ hco:Xq23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	109400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34526,7 +34526,7 @@ hco:Xq24
 	rdfs:label	"Xq24" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq24#GRCh37
+hco:Xq24\/GRCh37
 	rdf:type	hco:Xq24 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34535,16 +34535,16 @@ hco:Xq24#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	116500000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq24#GRCh38
+hco:Xq24\/GRCh38
 	rdf:type	hco:Xq24 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34553,12 +34553,12 @@ hco:Xq24#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	117400000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34566,7 +34566,7 @@ hco:Xq25
 	rdfs:label	"Xq25" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq25#GRCh37
+hco:Xq25\/GRCh37
 	rdf:type	hco:Xq25 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34575,16 +34575,16 @@ hco:Xq25#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	120900000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq25#GRCh38
+hco:Xq25\/GRCh38
 	rdf:type	hco:Xq25 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34593,12 +34593,12 @@ hco:Xq25#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	121800000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34606,7 +34606,7 @@ hco:Xq26.1
 	rdfs:label	"Xq26.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq26.1#GRCh37
+hco:Xq26.1\/GRCh37
 	rdf:type	hco:Xq26.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34615,16 +34615,16 @@ hco:Xq26.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	128700000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq26.1#GRCh38
+hco:Xq26.1\/GRCh38
 	rdf:type	hco:Xq26.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34633,12 +34633,12 @@ hco:Xq26.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	129500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34646,7 +34646,7 @@ hco:Xq26.2
 	rdfs:label	"Xq26.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq26.2#GRCh37
+hco:Xq26.2\/GRCh37
 	rdf:type	hco:Xq26.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -34655,16 +34655,16 @@ hco:Xq26.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	130400000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq26.2#GRCh38
+hco:Xq26.2\/GRCh38
 	rdf:type	hco:Xq26.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos25 ;
@@ -34673,12 +34673,12 @@ hco:Xq26.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	131300000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34686,7 +34686,7 @@ hco:Xq26.3
 	rdfs:label	"Xq26.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq26.3#GRCh37
+hco:Xq26.3\/GRCh37
 	rdf:type	hco:Xq26.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34695,16 +34695,16 @@ hco:Xq26.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	133600000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq26.3#GRCh38
+hco:Xq26.3\/GRCh38
 	rdf:type	hco:Xq26.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34713,12 +34713,12 @@ hco:Xq26.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	134500000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34726,7 +34726,7 @@ hco:Xq27.1
 	rdfs:label	"Xq27.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq27.1#GRCh37
+hco:Xq27.1\/GRCh37
 	rdf:type	hco:Xq27.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34735,16 +34735,16 @@ hco:Xq27.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138000000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq27.1#GRCh38
+hco:Xq27.1\/GRCh38
 	rdf:type	hco:Xq27.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos75 ;
@@ -34753,12 +34753,12 @@ hco:Xq27.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	138900000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141200000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34766,7 +34766,7 @@ hco:Xq27.2
 	rdfs:label	"Xq27.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq27.2#GRCh37
+hco:Xq27.2\/GRCh37
 	rdf:type	hco:Xq27.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34775,16 +34775,16 @@ hco:Xq27.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	140300000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq27.2#GRCh38
+hco:Xq27.2\/GRCh38
 	rdf:type	hco:Xq27.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34793,12 +34793,12 @@ hco:Xq27.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	141200000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34806,7 +34806,7 @@ hco:Xq27.3
 	rdfs:label	"Xq27.3" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq27.3#GRCh37
+hco:Xq27.3\/GRCh37
 	rdf:type	hco:Xq27.3 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34815,16 +34815,16 @@ hco:Xq27.3#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	142100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq27.3#GRCh38
+hco:Xq27.3\/GRCh38
 	rdf:type	hco:Xq27.3 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos100 ;
@@ -34833,12 +34833,12 @@ hco:Xq27.3#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	143000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34846,7 +34846,7 @@ hco:Xq28
 	rdfs:label	"Xq28" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Xq28#GRCh37
+hco:Xq28\/GRCh37
 	rdf:type	hco:Xq28 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34855,16 +34855,16 @@ hco:Xq28#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	147100000 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	155270560 ;
-			faldo:reference	hco:X#GRCh37
+			faldo:reference	hco:X\/GRCh37
 		]
 	] .
 
-hco:Xq28#GRCh38
+hco:Xq28\/GRCh38
 	rdf:type	hco:Xq28 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34873,12 +34873,12 @@ hco:Xq28#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	148000000 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	156040895 ;
-			faldo:reference	hco:X#GRCh38
+			faldo:reference	hco:X\/GRCh38
 		]
 	] .
 
@@ -34886,7 +34886,7 @@ hco:Yp11.32
 	rdfs:label	"Yp11.32" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yp11.32#GRCh37
+hco:Yp11.32\/GRCh37
 	rdf:type	hco:Yp11.32 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34895,16 +34895,16 @@ hco:Yp11.32#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2500000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yp11.32#GRCh38
+hco:Yp11.32\/GRCh38
 	rdf:type	hco:Yp11.32 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34913,12 +34913,12 @@ hco:Yp11.32#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	0 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	300000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -34926,7 +34926,7 @@ hco:Yp11.31
 	rdfs:label	"Yp11.31" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yp11.31#GRCh37
+hco:Yp11.31\/GRCh37
 	rdf:type	hco:Yp11.31 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34935,16 +34935,16 @@ hco:Yp11.31#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	2500000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yp11.31#GRCh38
+hco:Yp11.31\/GRCh38
 	rdf:type	hco:Yp11.31 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -34953,12 +34953,12 @@ hco:Yp11.31#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	300000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -34966,7 +34966,7 @@ hco:Yp11.2
 	rdfs:label	"Yp11.2" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yp11.2#GRCh37
+hco:Yp11.2\/GRCh37
 	rdf:type	hco:Yp11.2 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -34975,16 +34975,16 @@ hco:Yp11.2#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	3000000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yp11.2#GRCh38
+hco:Yp11.2\/GRCh38
 	rdf:type	hco:Yp11.2 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -34993,12 +34993,12 @@ hco:Yp11.2#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10300000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35006,7 +35006,7 @@ hco:Yp11.1
 	rdfs:label	"Yp11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yp11.1#GRCh37
+hco:Yp11.1\/GRCh37
 	rdf:type	hco:Yp11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -35015,16 +35015,16 @@ hco:Yp11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	11600000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yp11.1#GRCh38
+hco:Yp11.1\/GRCh38
 	rdf:type	hco:Yp11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -35033,12 +35033,12 @@ hco:Yp11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10300000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10400000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35046,7 +35046,7 @@ hco:Yq11.1
 	rdfs:label	"Yq11.1" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.1#GRCh37
+hco:Yq11.1\/GRCh37
 	rdf:type	hco:Yq11.1 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Acen ;
@@ -35055,16 +35055,16 @@ hco:Yq11.1#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12500000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.1#GRCh38
+hco:Yq11.1\/GRCh38
 	rdf:type	hco:Yq11.1 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Acen ;
@@ -35073,12 +35073,12 @@ hco:Yq11.1#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10400000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35086,7 +35086,7 @@ hco:Yq11.21
 	rdfs:label	"Yq11.21" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.21#GRCh37
+hco:Yq11.21\/GRCh37
 	rdf:type	hco:Yq11.21 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -35095,16 +35095,16 @@ hco:Yq11.21#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	13400000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15100000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.21#GRCh38
+hco:Yq11.21\/GRCh38
 	rdf:type	hco:Yq11.21 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -35113,12 +35113,12 @@ hco:Yq11.21#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	10600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12400000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35126,7 +35126,7 @@ hco:Yq11.221
 	rdfs:label	"Yq11.221" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.221#GRCh37
+hco:Yq11.221\/GRCh37
 	rdf:type	hco:Yq11.221 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -35135,16 +35135,16 @@ hco:Yq11.221#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	15100000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19800000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.221#GRCh38
+hco:Yq11.221\/GRCh38
 	rdf:type	hco:Yq11.221 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -35153,12 +35153,12 @@ hco:Yq11.221#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	12400000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17100000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35166,7 +35166,7 @@ hco:Yq11.222
 	rdfs:label	"Yq11.222" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.222#GRCh37
+hco:Yq11.222\/GRCh37
 	rdf:type	hco:Yq11.222 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -35175,16 +35175,16 @@ hco:Yq11.222#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19800000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22100000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.222#GRCh38
+hco:Yq11.222\/GRCh38
 	rdf:type	hco:Yq11.222 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -35193,12 +35193,12 @@ hco:Yq11.222#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	17100000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35206,7 +35206,7 @@ hco:Yq11.223
 	rdfs:label	"Yq11.223" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.223#GRCh37
+hco:Yq11.223\/GRCh37
 	rdf:type	hco:Yq11.223 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -35215,16 +35215,16 @@ hco:Yq11.223#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	22100000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.223#GRCh38
+hco:Yq11.223\/GRCh38
 	rdf:type	hco:Yq11.223 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gpos50 ;
@@ -35233,12 +35233,12 @@ hco:Yq11.223#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	19600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35246,7 +35246,7 @@ hco:Yq11.23
 	rdfs:label	"Yq11.23" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq11.23#GRCh37
+hco:Yq11.23\/GRCh37
 	rdf:type	hco:Yq11.23 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gneg ;
@@ -35255,16 +35255,16 @@ hco:Yq11.23#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26200000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq11.23#GRCh38
+hco:Yq11.23\/GRCh38
 	rdf:type	hco:Yq11.23 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gneg ;
@@ -35273,12 +35273,12 @@ hco:Yq11.23#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	23800000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 
@@ -35286,7 +35286,7 @@ hco:Yq12
 	rdfs:label	"Yq12" ;
 	rdfs:subClassOf	hco:Cytoband .
 
-hco:Yq12#GRCh37
+hco:Yq12\/GRCh37
 	rdf:type	hco:Yq12 ;
 	hco:build	hco:GRCh37 ;
 	hco:bandtype	hco:Gvar ;
@@ -35295,16 +35295,16 @@ hco:Yq12#GRCh37
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	28800000 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	59373566 ;
-			faldo:reference	hco:Y#GRCh37
+			faldo:reference	hco:Y\/GRCh37
 		]
 	] .
 
-hco:Yq12#GRCh38
+hco:Yq12\/GRCh38
 	rdf:type	hco:Yq12 ;
 	hco:build	hco:GRCh38 ;
 	hco:bandtype	hco:Gvar ;
@@ -35313,12 +35313,12 @@ hco:Yq12#GRCh38
 		faldo:begin	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	26600000 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		] ;
 		faldo:end	[
 			rdf:type	faldo:BothStrandsPosition ;
 			faldo:position	57227415 ;
-			faldo:reference	hco:Y#GRCh38
+			faldo:reference	hco:Y\/GRCh38
 		]
 	] .
 

--- a/hco_head.owl
+++ b/hco_head.owl
@@ -1,0 +1,844 @@
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix obo:   <http://purl.obolibrary.org/obo/> .
+@prefix faldo: <http://biohackathon.org/resource/faldo#> .
+@prefix hco:   <http://identifiers.org/hco/> .
+
+# Base classes and properties
+
+<http://identifiers.org/hco/>
+	rdf:type	owl:Ontology ;
+	dct:license	<http://creativecommons.org/publicdomain/zero/1.0/> ;
+	rdfs:seeAlso	<https://github.com/med2rdf/hco/> ;
+	owl:versionInfo "2018-04-09"^^xsd:date .
+
+hco:HumanChromosome
+	rdf:type	owl:Class ;
+	rdfs:label	"Human chromosome" ;
+	skos:definition	"Collection of human chromosomes" ;
+	rdfs:seeAlso	<http://identifiers.org/taxonomy/9606> ;
+	skos:broader	obo:SO_0000340 .    # chromosome
+
+hco:GenomeBuild
+	rdf:type	owl:Class ;
+	rdfs:label	"Genome build" ;
+	skos:definition	"Version of a genome assembly" ;
+	skos:broader	obo:SO_0001505 .    # reference_genome
+
+hco:Cytoband
+	rdf:type	owl:Class ;
+	rdfs:label	"Cytoband" ;
+	skos:definition	"Chromosome band" ;
+	skos:broader	obo:SO_0000341 .    # chromosome_band
+
+hco:CytobandType
+	rdf:type	owl:Class ;
+	rdfs:label	"Cytoband type" ;
+	skos:definition	"Cytoband types including Giemsa-banding annotations" .
+
+hco:build
+	rdfs:type	owl:ObjectProperty ;
+	rdfs:label	"build" ;
+	rdfs:domain	hco:HumanChromosome ;
+	rdfs:range	hco:GenomeBuild .
+
+hco:insdc
+	rdfs:type	owl:ObjectProperty ;
+	rdfs:label	"INSDC" ;
+	rdfs:domain	hco:HumanChromosome ;
+	rdfs:range	rdfs:Resource .
+
+hco:refseq
+	rdfs:type	owl:ObjectProperty ;
+	rdfs:label	"RefSeq" ;
+	rdfs:domain	hco:HumanChromosome ;
+	rdfs:range	rdfs:Resource .
+
+hco:ucsc
+	rdfs:type	owl:ObjectProperty ;
+	rdfs:label	"UCSC" ;
+	rdfs:domain	hco:HumanChromosome ;
+	rdfs:range	rdfs:Resource .
+
+hco:ensembl
+	rdfs:type	owl:ObjectProperty ;
+	rdfs:label	"Ensembl" ;
+	rdfs:domain	hco:HumanChromosome ;
+	rdfs:range	rdfs:Resource .
+
+hco:length
+	rdfs:type	owl:DatatypeProperty ;
+	rdfs:label	"length" ;
+	rdfs:domain	hco:GenomeBuild ;
+	rdfs:range	xsd:integer .
+
+hco:bandtype
+	rdfs:type	owl:DatatypeProperty ;
+	rdfs:label	"cytoband type" ;
+	rdfs:domain	hco:Cytoband ;
+	rdfs:range	hco:CytobandType .
+
+# Human chromosome classes and instances
+
+hco:1
+	rdfs:label	"Human chromosome 1" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:1\/GRCh37
+	rdf:type	hco:1 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	249250621 ;
+	skos:altLabel	"GPC_000000025" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000663.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000001.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr1> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/1> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=1> .
+
+hco:1\/GRCh38
+	rdf:type	hco:1 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	248956422 ;
+	skos:altLabel	"GPC_000001293" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000663.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000001.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr1> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/1> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=1> .
+
+hco:2
+	rdfs:label	"Human chromosome 2" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:2\/GRCh37
+	rdf:type	hco:2 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	243199373 ;
+	skos:altLabel	"GPC_000000026" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000664.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000002.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr2> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/2> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=2> .
+
+hco:2\/GRCh38
+	rdf:type	hco:2 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	242193529 ;
+	skos:altLabel	"GPC_000001294" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000664.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000002.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr2> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/2> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=2> .
+
+hco:3
+	rdfs:label	"Human chromosome 3" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:3\/GRCh37
+	rdf:type	hco:3 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	198022430 ;
+	skos:altLabel	"GPC_000000027" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000665.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000003.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr3> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/3> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=3> .
+
+hco:3\/GRCh38
+	rdf:type	hco:3 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	198295559 ;
+	skos:altLabel	"GPC_000001295" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000665.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000003.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr3> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/3> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=3> .
+
+hco:4
+	rdfs:label	"Human chromosome 4" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:4\/GRCh37
+	rdf:type	hco:4 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	191154276 ;
+	skos:altLabel	"GPC_000000028" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000666.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000004.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr4> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/4> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=4> .
+
+hco:4\/GRCh38
+	rdf:type	hco:4 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	190214555 ;
+	skos:altLabel	"GPC_000001296" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000666.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000004.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr4> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/4> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=4> .
+
+hco:5
+	rdfs:label	"Human chromosome 5" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:5\/GRCh37
+	rdf:type	hco:5 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	180915260 ;
+	skos:altLabel	"GPC_000000029" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000667.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000005.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr5> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/5> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=5> .
+
+hco:5\/GRCh38
+	rdf:type	hco:5 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	181538259 ;
+	skos:altLabel	"GPC_000001297" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000667.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000005.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr5> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/5> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=5> .
+
+hco:6
+	rdfs:label	"Human chromosome 6" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:6\/GRCh37
+	rdf:type	hco:6 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	171115067 ;
+	skos:altLabel	"GPC_000000030" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000668.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000006.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr6> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/6> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=6> .
+
+hco:6\/GRCh38
+	rdf:type	hco:6 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	170805979 ;
+	skos:altLabel	"GPC_000001298" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000668.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000006.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr6> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/6> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=6> .
+
+hco:7
+	rdfs:label	"Human chromosome 7" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:7\/GRCh37
+	rdf:type	hco:7 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	159138663 ;
+	skos:altLabel	"GPC_000000031" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000669.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000007.13> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr7> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/7> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=7> .
+
+hco:7\/GRCh38
+	rdf:type	hco:7 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	159345973 ;
+	skos:altLabel	"GPC_000001299" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000669.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000007.14> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr7> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/7> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=7> .
+
+hco:8
+	rdfs:label	"Human chromosome 8" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:8\/GRCh37
+	rdf:type	hco:8 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	146364022 ;
+	skos:altLabel	"GPC_000000032" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000670.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000008.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr8> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/8> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=8> .
+
+hco:8\/GRCh38
+	rdf:type	hco:8 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	145138636 ;
+	skos:altLabel	"GPC_000001300" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000670.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000008.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr8> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/8> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=8> .
+
+hco:9
+	rdfs:label	"Human chromosome 9" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:9\/GRCh37
+	rdf:type	hco:9 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	141213431 ;
+	skos:altLabel	"GPC_000000033" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000671.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000009.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr9> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/9> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=9> .
+
+hco:9\/GRCh38
+	rdf:type	hco:9 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	138394717 ;
+	skos:altLabel	"GPC_000001301" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000671.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000009.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr9> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/9> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=9> .
+
+hco:10
+	rdfs:label	"Human chromosome 10" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:10\/GRCh37
+	rdf:type	hco:10 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	135534747 ;
+	skos:altLabel	"GPC_000000034" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000672.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000010.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr10> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/10> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=10> .
+
+hco:10\/GRCh38
+	rdf:type	hco:1 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	133797422 ;
+	skos:altLabel	"GPC_000001302" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000672.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000010.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr10> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/10> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=10> .
+
+hco:11
+	rdfs:label	"Human chromosome 11" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:11\/GRCh37
+	rdf:type	hco:11 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	135006516 ;
+	skos:altLabel	"GPC_000000035" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000673.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000011.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr11> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/11> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=11> .
+
+hco:11\/GRCh38
+	rdf:type	hco:11 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	135086622 ;
+	skos:altLabel	"GPC_000001303" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000673.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000011.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr11> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/11> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=11> .
+
+hco:12
+	rdfs:label	"Human chromosome 12" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:12\/GRCh37
+	rdf:type	hco:12 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	133851895 ;
+	skos:altLabel	"GPC_000000036" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000674.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000012.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr12> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/12> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=12> .
+
+hco:12\/GRCh38
+	rdf:type	hco:12 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	133275309 ;
+	skos:altLabel	"GPC_000001304" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000674.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000012.12> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr12> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/12> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=12> .
+
+hco:13
+	rdfs:label	"Human chromosome 13" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:13\/GRCh37
+	rdf:type	hco:13 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	115169878 ;
+	skos:altLabel	"GPC_000000037" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000675.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000013.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr13> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/13> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=13> .
+
+hco:13\/GRCh38
+	rdf:type	hco:13 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	114364328 ;
+	skos:altLabel	"GPC_000001305" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000675.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000013.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr13> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/13> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=13> .
+
+hco:14
+	rdfs:label	"Human chromosome 14" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:14\/GRCh37
+	rdf:type	hco:14 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	107349540 ;
+	skos:altLabel	"GPC_000000038" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000676.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000014.8> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr14> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/14> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=14> .
+
+hco:14\/GRCh38
+	rdf:type	hco:14 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	107043718 ;
+	skos:altLabel	"GPC_000001306" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000676.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000014.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr14> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/14> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=14> .
+
+hco:15
+	rdfs:label	"Human chromosome 15" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:15\/GRCh37
+	rdf:type	hco:15 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	102531392 ;
+	skos:altLabel	"GPC_000000039" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000677.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000015.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr15> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/15> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=15> .
+
+hco:15\/GRCh38
+	rdf:type	hco:15 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	101991189 ;
+	skos:altLabel	"GPC_000001307" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000677.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000015.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr15> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/15> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=15> .
+
+hco:16
+	rdfs:label	"Human chromosome 16" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:16\/GRCh37
+	rdf:type	hco:16 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	90354753 ;
+	skos:altLabel	"GPC_000000040" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000678.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000016.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr16> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/16> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=16> .
+
+hco:16\/GRCh38
+	rdf:type	hco:16 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	90338345 ;
+	skos:altLabel	"GPC_000001308" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000678.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000016.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr16> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/16> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=16> .
+
+hco:17
+	rdfs:label	"Human chromosome 17" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:17\/GRCh37
+	rdf:type	hco:17 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	81195210 ;
+	skos:altLabel	"GPC_000000041" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000679.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000017.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr17> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/17> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=17> .
+
+hco:17\/GRCh38
+	rdf:type	hco:17 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	83257441 ;
+	skos:altLabel	"GPC_000001309" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000679.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000017.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr17> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/17> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=17> .
+
+hco:18
+	rdfs:label	"Human chromosome 18" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:18\/GRCh37
+	rdf:type	hco:18 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	78077248 ;
+	skos:altLabel	"GPC_000000042" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000680.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000018.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr18> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/18> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=18> .
+
+hco:18\/GRCh38
+	rdf:type	hco:18 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	80373285 ;
+	skos:altLabel	"GPC_000001310" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000680.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000018.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr18> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/18> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=18> .
+
+hco:19
+	rdfs:label	"Human chromosome 19" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:19\/GRCh37
+	rdf:type	hco:19 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	59128983 ;
+	skos:altLabel	"GPC_000000043" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000681.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000019.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr19> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/19> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=19> .
+
+hco:19\/GRCh38
+	rdf:type	hco:19 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	58617616 ;
+	skos:altLabel	"GPC_000001311" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000681.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000019.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chg38> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/19> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=19> .
+
+hco:20
+	rdfs:label	"Human chromosome 20" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:20\/GRCh37
+	rdf:type	hco:20 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	63025520 ;
+	skos:altLabel	"GPC_000000044" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000682.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000020.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr20> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/20> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=20> .
+
+hco:20\/GRCh38
+	rdf:type	hco:20 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	64444167 ;
+	skos:altLabel	"GPC_000001312" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000682.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000020.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr20> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/20> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=20> .
+
+hco:21
+	rdfs:label	"Human chromosome 21" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:21\/GRCh37
+	rdf:type	hco:21 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	48129895 ;
+	skos:altLabel	"GPC_000000045" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000683.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000021.8> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr21> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/21> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=21> .
+
+hco:21\/GRCh38
+	rdf:type	hco:21 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	46709983 ;
+	skos:altLabel	"GPC_000001313" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000683.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000021.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr21> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/21> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=21> .
+
+hco:22
+	rdfs:label	"Human chromosome 22" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:22\/GRCh37
+	rdf:type	hco:22 ;
+	hco:build	hco:GRCh37 ;
+	hco:length	51304566 ;
+	skos:altLabel	"GPC_000000046" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000684.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000022.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr22> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/22> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=22> .
+
+hco:22\/GRCh38
+	rdf:type	hco:22 ;
+	hco:build	hco:GRCh38 ;
+	hco:length	50818468 ;
+	skos:altLabel	"GPC_000001314" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000684.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000022.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chr22> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/22> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=22> .
+
+hco:X
+	rdfs:label	"Human chromosome X" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:X\/GRCh37
+	rdf:type	hco:X ;
+	hco:build	hco:GRCh37 ;
+	hco:length	155270560 ;
+	skos:altLabel	"GPC_000000047" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000685.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000023.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chrX> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/X> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=X> .
+
+hco:X\/GRCh38
+	rdf:type	hco:X ;
+	hco:build	hco:GRCh38 ;
+	hco:length	156040895 ;
+	skos:altLabel	"GPC_000001315" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000685.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000023.11> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chrX> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/X> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=X> .
+
+hco:Y
+	rdfs:label	"Human chromosome Y" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:Y\/GRCh37
+	rdf:type	hco:Y ;
+	hco:build	hco:GRCh37 ;
+	hco:length	59373566 ;
+	skos:altLabel	"GPC_000000048" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000686.1> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000024.9> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chrY> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/Y> ,
+			<http://grch37.ensembl.org/Homo_sapiens/Location/Chromosome?r=Y> .
+
+hco:Y\/GRCh38
+	rdf:type	hco:Y ;
+	hco:build	hco:GRCh38 ;
+	hco:length	57227415 ;
+	skos:altLabel	"GPC_000001316" ;
+	hco:insdc	<http://identifiers.org/insdc/CM000686.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_000024.10> ;
+	hco:ucsc	<http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=chrY> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/Y> ,
+			<http://www.ensembl.org/Homo_sapiens/Location/Chromosome?r=Y> .
+
+hco:MT
+	rdfs:label	"Human mitochondrion genome" ;
+	rdfs:subClassOf	hco:HumanChromosome .
+
+hco:MT\/GRCh37
+	rdf:type	hco:MT ;
+	hco:length	16569 ;
+	skos:altLabel	"AC_000021" ;
+	hco:insdc	<http://identifiers.org/insdc/J01415.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_012920.1> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh37/MT> .
+
+hco:MT\/GRCh38
+	rdf:type	hco:MT ;
+	hco:length	16569 ;
+	skos:altLabel	"AC_000021" ;
+	hco:insdc	<http://identifiers.org/insdc/J01415.2> ;
+	hco:refseq	<http://identifiers.org/refseq/NC_012920.1> ;
+	hco:ensembl	<http://rdf.ebi.ac.uk/resource/ensembl/homo_sapiens/GRCh38/MT> .
+
+# Human genome build classes and instances
+
+hco:GRCh37
+	rdfs:label	"GRCh37" ;
+	skos:definition	"Genome Reference Consortium Human Build 37" ;
+	skos:altLabel	"hg19" ;
+	rdfs:subClassOf	hco:GenomeBuild .
+
+hco:GRCh37.p0
+	rdfs:label	"GRCh37.p0" ;
+	skos:definition	"Genome Reference Consortium Human Build 37" ;
+	hco:length	3137144693;
+	dct:date	"2009-02-27"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.1> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.13> ;
+	rdf:type	hco:GRCh37 .
+
+hco:GRCh37.p13
+	rdfs:label	"GRCh37.p13" ;
+	skos:definition	"Genome Reference Consortium Human Build 37 patch release 13" ;
+	hco:length	3234834689 ;
+	dct:date	"2013-06-28"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.14> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.25> ;
+	rdf:type	hco:GRCh37 .
+
+hco:GRCh38
+	rdfs:label	"GRCh38" ;
+	skos:definition	"Genome Reference Consortium Human Build 38" ;
+	skos:altLabel	"hg38" ;
+	rdfs:subClassOf	hco:GenomeBuild .
+
+hco:GRCh38.p0
+	rdfs:label	"GRCh38.p0" ;
+	skos:definition	"Genome Reference Consortium Human Build 38" ;
+	skos:altLabel	"hg38" ;
+	hco:length	3209286105 ;
+	dct:date	"2013-12-17"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.15> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.26> ;
+	rdf:type	hco:GenomeBuild .
+
+hco:GRCh38.p7  # Previous RefSeq version
+	rdfs:label	"GRCh38.p7" ;
+	skos:definition	"Genome Reference Consortium Human Build 38 patch release 7" ;
+	skos:altLabel	"hg38" ;
+	hco:length	3232546710 ;
+	dct:date	"2016-03-21"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.22> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.33> ;
+	rdf:type	hco:GenomeBuild .
+
+hco:GRCh38.p10  # Previous Ensembl version
+	rdfs:label	"GRCh38.p10" ;
+	skos:definition	"Genome Reference Consortium Human Build 38 patch release 10" ;
+	skos:altLabel	"hg38" ;
+	hco:length	3241953429 ;
+	dct:date	"2017-01-06"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.25> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.36> ;
+	rdf:type	hco:GenomeBuild .
+
+hco:GRCh38.p12  # Current version
+	rdfs:label	"GRCh38.p12" ;
+	skos:definition	"Genome Reference Consortium Human Build 38 patch release 12" ;
+	skos:altLabel	"hg38" ;
+	hco:length	3257319537 ;
+	dct:date	"2017-12-21"^^xsd:date ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCA_000001405.27> ;
+	rdfs:seeAlso	<https://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.38> ;
+	rdf:type	hco:GenomeBuild .
+
+# Cytoband classes and instances
+
+hco:Acen
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"acen" ;
+	skos:definition	"Centromeric region" .
+
+hco:Gneg
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gneg" ;
+	skos:definition	"Giemsa negative band" .
+
+hco:Gpos100
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gpos100" ;
+	skos:definition	"Giemsa positive band, the darkest stain level" .
+
+hco:Gpos25
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gpos25" ;
+	skos:definition	"Giemsa positive band, the lightest stain level" .
+
+hco:Gpos50
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gpos50" ;
+	skos:definition	"Giemsa positive band, the second lightest stain level" .
+
+hco:Gpos75
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gpos75" ;
+	skos:definition	"Giemsa positive band, the second darkest stain level" .
+
+hco:Gvar
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"gvar" ;
+	rdfs:definition "Variable length heterochromatic region." .
+
+hco:Stalk
+	rdf:type	hco:CytobandType ;
+	rdfs:label	"stalk" ;
+	skos:definition	"Short arm of the acrocentric chromosomes." .
+


### PR DESCRIPTION
This update contains an incompatible change to the URI. All RDF data using the old notation `hco:21\#GRCh38` to the new one `hco:21\/GRCh38`. This enables users to use custom fragment URI such as

```
http://identifiers.org/hco/21/GRCh38#12345-G-A
```

which looks odd in the previous version:

```
http://identifiers.org/hco/21#GRCh38#12345-G-A
```